### PR TITLE
Fix language in string length constraints

### DIFF
--- a/src/Constraints/StringMaxLengthConstraint.php
+++ b/src/Constraints/StringMaxLengthConstraint.php
@@ -18,7 +18,7 @@ class StringMaxLengthConstraint {
           'expected' => $maximum,
           'got' => $length,
         ),
-        'message' => "must be less than {$maximum} characters",
+        'message' => "must be less than ".($maximum+1)." characters",
       );
       throw new JsonSchema\InvalidFieldException($pointer, vec[$error]);
     }

--- a/src/Constraints/StringMinLengthConstraint.php
+++ b/src/Constraints/StringMinLengthConstraint.php
@@ -18,7 +18,7 @@ class StringMinLengthConstraint {
           'expected' => $minimum,
           'got' => $length,
         ),
-        'message' => "must be less than {$minimum} characters",
+        'message' => "must be more than ".($minimum-1)." characters",
       );
       throw new JsonSchema\InvalidFieldException($pointer, vec[$error]);
     }


### PR DESCRIPTION
The `minLength` string constraint uses the same language as the `maxLength` constraint which can cause confusion where there are errors.

Separately, I think both min and max length have an off-by-one error between the check and the user language. For example, `StringMaxLengthConstraint ` checks that `$length > $maximum` and the error tells the user that length "must be less than {$maximum} characters" (even though being `$maximum` characters would be OK).