### PR TITLE
Use `HH\dict` to not do duplicate work + perf

### DIFF
--- a/src/Constraints/ObjectConstraint.php
+++ b/src/Constraints/ObjectConstraint.php
@@ -25,17 +25,18 @@ class ObjectConstraint {
       } else {
         $darray_spec = TypeSpec\dict_like_array(TypeSpec\string(), TypeSpec\mixed());
         # Fallback to checking legacy PHP dict-like-arrays
-        $darray_spec->assertType($input);
-
-        # Coerce a valid dict-like-array to a dict.
-        return $dict_spec->coerceType($input);
+        return dict($darray_spec->assertType($input));
       }
     } catch (TypeAssert\IncorrectTypeException $e) {
       self::throwInvalidInput($pointer);
+      // Do not remove this catch until TypeAssert 3.6.2 is a requirement.
+      // TypeSpec\dict(...)->assertType(...) throws an TypeCoersionException under 3.6.1 and below.
+      // This is should have been an IncorrectTypeException and this has since been rectified.
+      // This library builds against 3.6.1- and 3.6.2+, so both exceptions need to be caught.
+      // In future, remove this second catch and inline the body of throwInvalidInput here.
     } catch (TypeAssert\TypeCoercionException $e) {
       self::throwInvalidInput($pointer);
     }
-
   }
 
   private static function throwInvalidInput(string $pointer): noreturn {


### PR DESCRIPTION
I have read this code a bit more carefully and reasoned about the coerce
Under all previous versions this function first asserts dict<str, mixed>
If that fails it will assert dict_like_array<str, mixed>
Coercing the dict will never fail, since the key and value type are okay
So the coercion will only cast the array to a dict
This can be done more efficiently using `HH\dict`
This prevents doing work revalidating the keys and values twice