### PR TITLE
remove HH_IGNORE_ERROR that's no longer needed

### DIFF
--- a/src/Codegen/Constraints/ObjectBuilder.php
+++ b/src/Codegen/Constraints/ObjectBuilder.php
@@ -439,7 +439,6 @@ class ObjectBuilder extends BaseBuilder<TObjectSchema> {
 
     if ($properties is nonnull) {
       $hb
-        ->addLine("/* HH_IGNORE_ERROR[4057] */")
         ->addLine("/* HH_IGNORE_ERROR[4163] */")
         ->addReturn('$output', HackBuilderValues::literal());
     } else if (


### PR DESCRIPTION
this PR removes an `HH_IGNORE_ERROR` that is inserted into generate code that no longer appears necessary based on running `hh_client --remove-dead-fixmes` against generated code.

the risk of this PR is fairly low as there is no functional change — only potential impact to consumers' typecheckers.