### PR TITLE
Mark all test files as `// strict`

### DIFF
--- a/tests/AddressSchemaValidatorTest.php
+++ b/tests/AddressSchemaValidatorTest.php
@@ -1,14 +1,11 @@
-<?hh // partial
+<?hh // strict
 
 namespace Slack\Hack\JsonSchema\Tests;
 
 use namespace HH\Lib\C;
 use function Facebook\FBExpect\expect;
 
-use type Slack\Hack\JsonSchema\Tests\Generated\{
-  AddressSchemaFileValidator,
-  AddressSchemaValidator,
-};
+use type Slack\Hack\JsonSchema\Tests\Generated\{AddressSchemaFileValidator, AddressSchemaValidator};
 
 final class AddressSchemaValidatorTest extends BaseCodegenTestCase {
 
@@ -16,10 +13,7 @@ final class AddressSchemaValidatorTest extends BaseCodegenTestCase {
   public static async function beforeFirstTestAsync(): Awaitable<void> {
     $ret = self::getBuilder('address-schema.json', 'AddressSchemaValidator');
     $ret['codegen']->build();
-    $ret_remote = self::getBuilder(
-      'address-schema-remote.json',
-      'AddressSchemaFileValidator',
-    );
+    $ret_remote = self::getBuilder('address-schema-remote.json', 'AddressSchemaFileValidator');
     $ret_remote['codegen']->build();
     require_once($ret['path']);
     require_once($ret_remote['path']);
@@ -63,9 +57,7 @@ final class AddressSchemaValidatorTest extends BaseCodegenTestCase {
     ]);
     $validator->validate();
 
-    expect($validator->isValid())->toBeTrue(
-      'numeric postal codes should be valid',
-    );
+    expect($validator->isValid())->toBeTrue('numeric postal codes should be valid');
   }
 
   public function testAddressWithInvalidPostalCode(): void {
@@ -93,9 +85,7 @@ final class AddressSchemaValidatorTest extends BaseCodegenTestCase {
     ]);
     $validator->validate();
 
-    expect($validator->isValid())->toBeTrue(
-      'file reference to phone type should be valid',
-    );
+    expect($validator->isValid())->toBeTrue('file reference to phone type should be valid');
   }
 
   public function testAddressWithSizeAllOf(): void {
@@ -106,9 +96,7 @@ final class AddressSchemaValidatorTest extends BaseCodegenTestCase {
       'size' => 200,
     ]);
     $validator->validate();
-    expect($validator->isValid())->toBeTrue(
-      'should be valid as 200 is both an integer and a number',
-    );
+    expect($validator->isValid())->toBeTrue('should be valid as 200 is both an integer and a number');
   }
 
   public function testAddressWithSizeAllOfFailure(): void {
@@ -119,9 +107,7 @@ final class AddressSchemaValidatorTest extends BaseCodegenTestCase {
       'size' => 200.5,
     ]);
     $validator->validate();
-    expect($validator->isValid())->toBeFalse(
-      'should not be valid as 200.5 is not an integer',
-    );
+    expect($validator->isValid())->toBeFalse('should not be valid as 200.5 is not an integer');
   }
 
   public function testAddressWithLongitudeNot(): void {
@@ -132,9 +118,7 @@ final class AddressSchemaValidatorTest extends BaseCodegenTestCase {
       'longitude' => 200.5,
     ]);
     $validator->validate();
-    expect($validator->isValid())->toBeTrue(
-      'should be valid as 200.5 is not an integer nor a string',
-    );
+    expect($validator->isValid())->toBeTrue('should be valid as 200.5 is not an integer nor a string');
   }
 
   public function testAddressWithLongitudeNotFailure(): void {
@@ -145,9 +129,7 @@ final class AddressSchemaValidatorTest extends BaseCodegenTestCase {
       'longitude' => 200,
     ]);
     $validator->validate();
-    expect($validator->isValid())->toBeFalse(
-      'should not be valid as 200 is an integer',
-    );
+    expect($validator->isValid())->toBeFalse('should not be valid as 200 is an integer');
   }
 
   public function testAddressWithLatitudeOneOf(): void {
@@ -158,9 +140,7 @@ final class AddressSchemaValidatorTest extends BaseCodegenTestCase {
       'latitude' => 200.5,
     ]);
     $validator->validate();
-    expect($validator->isValid())->toBeTrue(
-      'should be valid as 200.5 is not an integer but is a number',
-    );
+    expect($validator->isValid())->toBeTrue('should be valid as 200.5 is not an integer but is a number');
   }
 
   public function testAddressWithLatitudeOneOfFailure(): void {
@@ -171,9 +151,7 @@ final class AddressSchemaValidatorTest extends BaseCodegenTestCase {
       'latitude' => 200,
     ]);
     $validator->validate();
-    expect($validator->isValid())->toBeFalse(
-      'should not be valid as 200 is an integer and number',
-    );
+    expect($validator->isValid())->toBeFalse('should not be valid as 200 is an integer and number');
   }
 
   public function testAddressWithFailedFileRef(): void {
@@ -188,9 +166,7 @@ final class AddressSchemaValidatorTest extends BaseCodegenTestCase {
       ],
     ]);
     $validator->validate();
-    expect($validator->isValid())->toBeFalse(
-      'file reference to phone type should be invalid',
-    );
+    expect($validator->isValid())->toBeFalse('file reference to phone type should be invalid');
     expect(C\count($validator->getErrors()))->toBeSame(3);
   }
 
@@ -209,9 +185,7 @@ final class AddressSchemaValidatorTest extends BaseCodegenTestCase {
     ]);
     $validator->validate();
 
-    expect($validator->isValid())->toBeTrue(
-      'file reference to phone type should be valid',
-    );
+    expect($validator->isValid())->toBeTrue('file reference to phone type should be valid');
   }
 
   public function testAddressWithFalseDepthRefs(): void {
@@ -229,9 +203,7 @@ final class AddressSchemaValidatorTest extends BaseCodegenTestCase {
     ]);
     $validator->validate();
 
-    expect($validator->isValid())->toBeFalse(
-      'file reference to phone type should be valid',
-    );
+    expect($validator->isValid())->toBeFalse('file reference to phone type should be valid');
     expect(C\count($validator->getErrors()))->toBeSame(2);
   }
 

--- a/tests/AnyOfRefiningTest.php
+++ b/tests/AnyOfRefiningTest.php
@@ -1,15 +1,10 @@
-<?hh // partial
+<?hh // strict
 
 namespace Slack\Hack\JsonSchema\Tests;
 
 use function Facebook\FBExpect\expect;
 
-use type Slack\Hack\JsonSchema\Tests\Generated\{
-  AnyOfValidator1,
-  AnyOfValidator2,
-  AnyOfValidator3,
-  AnyOfValidator4,
-};
+use type Slack\Hack\JsonSchema\Tests\Generated\{AnyOfValidator1, AnyOfValidator2, AnyOfValidator3, AnyOfValidator4};
 
 final class AnyOfRefiningTest extends BaseCodegenTestCase {
 

--- a/tests/ArraySchemaValidatorTest.php
+++ b/tests/ArraySchemaValidatorTest.php
@@ -1,4 +1,4 @@
-<?hh // partial
+<?hh // strict
 
 namespace Slack\Hack\JsonSchema\Tests;
 

--- a/tests/BaseCodegenTestCase.php
+++ b/tests/BaseCodegenTestCase.php
@@ -1,4 +1,4 @@
-<?hh // partial
+<?hh // strict
 
 namespace Slack\Hack\JsonSchema\Tests;
 

--- a/tests/BooleanSchemaValidatorTest.php
+++ b/tests/BooleanSchemaValidatorTest.php
@@ -1,4 +1,4 @@
-<?hh // partial
+<?hh // strict
 
 namespace Slack\Hack\JsonSchema\Tests;
 
@@ -65,9 +65,7 @@ final class BooleanSchemaValidatorTest extends BaseCodegenTestCase {
       ]);
       $validator->validate();
 
-      expect($validator->isValid())->toBeTrue(
-        "should be valid for input: '{$case['input']}'",
-      );
+      expect($validator->isValid())->toBeTrue("should be valid for input: '{$case['input']}'");
 
       $validated = $validator->getValidatedInput();
       expect($validated)->toNotBeNull('should be valid');

--- a/tests/CodegenForPathsTest.php
+++ b/tests/CodegenForPathsTest.php
@@ -1,4 +1,4 @@
-<?hh // partial
+<?hh // strict
 
 namespace Slack\Hack\JsonSchema\Tests;
 

--- a/tests/CustomCodegenConfigTest.php
+++ b/tests/CustomCodegenConfigTest.php
@@ -1,4 +1,4 @@
-<?hh // partial
+<?hh // strict
 
 namespace Slack\Hack\JsonSchema\Tests;
 

--- a/tests/DefaultsSchemaValidatorTest.php
+++ b/tests/DefaultsSchemaValidatorTest.php
@@ -1,4 +1,4 @@
-<?hh // partial
+<?hh // strict
 
 namespace Slack\Hack\JsonSchema\Tests;
 
@@ -74,19 +74,16 @@ final class DefaultsSchemaValidatorTest extends BaseCodegenTestCase {
     $_cases = vec[
       shape(
         'input' => darray[
-          'nested_coerce_false' =>
-            darray['boolean_prop' => 'false', 'number_prop' => 3],
+          'nested_coerce_false' => darray['boolean_prop' => 'false', 'number_prop' => 3],
         ],
         'output' => darray[
-          'nested_coerce_false' =>
-            darray['boolean_prop' => false, 'number_prop' => 3],
+          'nested_coerce_false' => darray['boolean_prop' => false, 'number_prop' => 3],
         ],
         'valid' => true,
       ),
       shape(
         'input' => darray[
-          'nested_coerce_false' =>
-            darray['boolean_prop' => true, 'number_prop' => '3'],
+          'nested_coerce_false' => darray['boolean_prop' => true, 'number_prop' => '3'],
         ],
         'valid' => false,
       ),

--- a/tests/EmptySchemaValidatorTest.php
+++ b/tests/EmptySchemaValidatorTest.php
@@ -1,4 +1,4 @@
-<?hh // partial
+<?hh // strict
 
 namespace Slack\Hack\JsonSchema\Tests;
 

--- a/tests/EnumSchemaValidatorTest.php
+++ b/tests/EnumSchemaValidatorTest.php
@@ -1,4 +1,4 @@
-<?hh // partial
+<?hh // strict
 
 namespace Slack\Hack\JsonSchema\Tests;
 

--- a/tests/FriendsSchemaValidatorTest.php
+++ b/tests/FriendsSchemaValidatorTest.php
@@ -1,4 +1,4 @@
-<?hh // partial
+<?hh // strict
 
 namespace Slack\Hack\JsonSchema\Tests;
 

--- a/tests/GeoSchemaValidatorTest.php
+++ b/tests/GeoSchemaValidatorTest.php
@@ -1,4 +1,4 @@
-<?hh // partial
+<?hh // strict
 
 namespace Slack\Hack\JsonSchema\Tests;
 
@@ -16,9 +16,7 @@ final class GeoSchemaValidatorTest extends BaseCodegenTestCase {
   }
 
   public function testValidateValidInput(): void {
-    $validator = new GeoSchemaValidator(
-      dict['latitude' => 37.7749, 'longitude' => 122.4194],
-    );
+    $validator = new GeoSchemaValidator(dict['latitude' => 37.7749, 'longitude' => 122.4194]);
     $validator->validate();
 
     expect($validator->isValid())->toBeTrue();
@@ -32,16 +30,14 @@ final class GeoSchemaValidatorTest extends BaseCodegenTestCase {
   }
 
   public function testValidateLatitudeOverMaximum(): void {
-    $validator =
-      new GeoSchemaValidator(dict['latitude' => 180, 'longitude' => 120]);
+    $validator = new GeoSchemaValidator(dict['latitude' => 180, 'longitude' => 120]);
     $validator->validate();
 
     expect($validator->isValid())->toBeFalse();
   }
 
   public function testValidateLongitudeOverMaximum(): void {
-    $validator =
-      new GeoSchemaValidator(dict['latitude' => 37, 'longitude' => 190]);
+    $validator = new GeoSchemaValidator(dict['latitude' => 37, 'longitude' => 190]);
     $validator->validate();
 
     expect($validator->isValid())->toBeFalse();

--- a/tests/NumericalSchemaValidatorTest.php
+++ b/tests/NumericalSchemaValidatorTest.php
@@ -1,4 +1,4 @@
-<?hh // partial
+<?hh // strict
 
 namespace Slack\Hack\JsonSchema\Tests;
 
@@ -9,8 +9,7 @@ final class NumericalSchemaValidatorTest extends BaseCodegenTestCase {
 
   <<__Override>>
   public static async function beforeFirstTestAsync(): Awaitable<void> {
-    $ret =
-      self::getBuilder('numerical-schema.json', 'NumericalSchemaValidator');
+    $ret = self::getBuilder('numerical-schema.json', 'NumericalSchemaValidator');
     $ret['codegen']->build();
     require_once($ret['path']);
   }

--- a/tests/ObjectSchemaValidatorTest.php
+++ b/tests/ObjectSchemaValidatorTest.php
@@ -1,4 +1,4 @@
-<?hh // partial
+<?hh // strict
 
 namespace Slack\Hack\JsonSchema\Tests;
 
@@ -32,9 +32,7 @@ final class ObjectSchemaValidatorTest extends BaseCodegenTestCase {
     expect($validator->isValid())->toBeFalse();
 
     $error = $validator->getErrors()[0];
-    expect($error['pointer'] ?? '')->toBeSame(
-      '/custom/root/only_properties/string',
-    );
+    expect($error['pointer'] ?? '')->toBeSame('/custom/root/only_properties/string');
   }
 
   public function testOnlyPropertiesDefaultStrings(): void {
@@ -105,9 +103,7 @@ final class ObjectSchemaValidatorTest extends BaseCodegenTestCase {
     expect($validator->isValid())->toBeTrue();
 
     $validated = $validator->getValidatedInput();
-    expect($validated['single_pattern_property_string'] ?? null)->toBeSame(
-      dict['S_string_value' => 'string value'],
-    );
+    expect($validated['single_pattern_property_string'] ?? null)->toBeSame(dict['S_string_value' => 'string value']);
   }
 
   public function testSinglePatternPropertyObject(): void {
@@ -258,8 +254,7 @@ final class ObjectSchemaValidatorTest extends BaseCodegenTestCase {
     expect(C\count($validator->getErrors()))->toBeSame(3);
   }
 
-  public function testPropertiesAndPatternPropertiesInvalidWithValidProperties(
-  ): void {
+  public function testPropertiesAndPatternPropertiesInvalidWithValidProperties(): void {
     $validator = new ObjectSchemaValidator(dict[
       'properties_and_pattern_properties' => dict[
         'string' => 12,
@@ -286,13 +281,12 @@ final class ObjectSchemaValidatorTest extends BaseCodegenTestCase {
     expect($validator->isValid())->toBeTrue();
 
     $validated = $validator->getValidatedInput();
-    expect(
-      $validated['properties_and_pattern_properties_no_additional'] ?? null,
-    )->toBeSame(shape('string' => 'some string value'));
+    expect($validated['properties_and_pattern_properties_no_additional'] ?? null)->toBeSame(
+      shape('string' => 'some string value'),
+    );
   }
 
-  public function testPropertiesAndPatternPropertiesNoAdditionalInvalidAdditional(
-  ): void {
+  public function testPropertiesAndPatternPropertiesNoAdditionalInvalidAdditional(): void {
     $validator = new ObjectSchemaValidator(dict[
       'properties_and_pattern_properties_no_additional' => dict[
         'string' => 'some string value',
@@ -383,8 +377,7 @@ final class ObjectSchemaValidatorTest extends BaseCodegenTestCase {
   public function testCoerceObjectValidString(): void {
     $input = darray['first' => 'first', 'second' => 2];
 
-    $validator =
-      new ObjectSchemaValidator(darray['coerce_object' => \json_encode($input)]);
+    $validator = new ObjectSchemaValidator(darray['coerce_object' => \json_encode($input)]);
     $validator->validate();
 
     expect($validator->isValid())->toBeTrue();
@@ -396,8 +389,7 @@ final class ObjectSchemaValidatorTest extends BaseCodegenTestCase {
   public function testCoerceObjectInvalidString(): void {
     $input = darray['first' => 2, 'second' => 'invalid'];
 
-    $validator =
-      new ObjectSchemaValidator(shape('coerce_object' => \json_encode($input)));
+    $validator = new ObjectSchemaValidator(shape('coerce_object' => \json_encode($input)));
     $validator->validate();
 
     expect($validator->isValid())->toBeFalse();
@@ -406,8 +398,7 @@ final class ObjectSchemaValidatorTest extends BaseCodegenTestCase {
 
   public function testImplicitAdditionalProperties(): void {
     $input = dict[
-      'implicit_additional_properties' =>
-        dict['first' => 'value', 'second' => 'value'],
+      'implicit_additional_properties' => dict['first' => 'value', 'second' => 'value'],
     ];
     $validator = new ObjectSchemaValidator($input);
     $validator->validate();
@@ -421,16 +412,12 @@ final class ObjectSchemaValidatorTest extends BaseCodegenTestCase {
       ),
     )->notToThrow("allows additional properties");
     $dynamic = Shapes::toDict($implicit);
-    expect($dynamic['second'])->toBeSame(
-      'value',
-      'additional property is present',
-    );
+    expect($dynamic['second'])->toBeSame('value', 'additional property is present');
   }
 
   public function testExplicitAdditionalProperties(): void {
     $input = dict[
-      'explicit_additional_properties' =>
-        dict['first' => 'value', 'second' => 'value'],
+      'explicit_additional_properties' => dict['first' => 'value', 'second' => 'value'],
     ];
     $validator = new ObjectSchemaValidator($input);
     $validator->validate();
@@ -444,16 +431,12 @@ final class ObjectSchemaValidatorTest extends BaseCodegenTestCase {
       ),
     )->notToThrow("allows additional properties");
     $dynamic = Shapes::toDict($explicit);
-    expect($dynamic['second'])->toBeSame(
-      'value',
-      'additional property is present',
-    );
+    expect($dynamic['second'])->toBeSame('value', 'additional property is present');
   }
 
   public function testNoAdditionalProperties(): void {
     $input = dict[
-      'no_additional_properties' =>
-        dict['first' => 'value', 'second' => 'value'],
+      'no_additional_properties' => dict['first' => 'value', 'second' => 'value'],
     ];
     $validator = new ObjectSchemaValidator($input);
     $validator->validate();

--- a/tests/PersonSchemaValidatorTest.php
+++ b/tests/PersonSchemaValidatorTest.php
@@ -1,4 +1,4 @@
-<?hh // partial
+<?hh // strict
 
 namespace Slack\Hack\JsonSchema\Tests;
 
@@ -19,14 +19,11 @@ final class PersonSchemaValidatorTest extends BaseCodegenTestCase {
     $validator = new PersonSchemaValidator(dict[]);
     $validator->validate();
 
-    expect($validator->isValid())->toBeFalse(
-      'should have failed on empty input',
-    );
+    expect($validator->isValid())->toBeFalse('should have failed on empty input');
   }
 
   public function testValidSchema(): void {
-    $input =
-      dict['first_name' => 'Michael', 'last_name' => 'Hahn', 'age' => 29];
+    $input = dict['first_name' => 'Michael', 'last_name' => 'Hahn', 'age' => 29];
 
     $validator = new PersonSchemaValidator($input);
     $validator->validate();
@@ -43,18 +40,14 @@ final class PersonSchemaValidatorTest extends BaseCodegenTestCase {
   }
 
   public function testInvalidPartialAge(): void {
-    $validator = new PersonSchemaValidator(
-      dict['first_name' => 'Michael', 'last_name' => 'Hahn', 'age' => 29.8],
-    );
+    $validator = new PersonSchemaValidator(dict['first_name' => 'Michael', 'last_name' => 'Hahn', 'age' => 29.8]);
     $validator->validate();
 
     expect($validator->isValid())->toBeFalse('should fail from partial age');
   }
 
   public function testNegativeAge(): void {
-    $validator = new PersonSchemaValidator(
-      dict['first_name' => 'Michael', 'last_name' => 'Hahn', 'age' => -29],
-    );
+    $validator = new PersonSchemaValidator(dict['first_name' => 'Michael', 'last_name' => 'Hahn', 'age' => -29]);
     $validator->validate();
 
     expect($validator->isValid())->toBeFalse('should fail from negative age');
@@ -85,9 +78,7 @@ final class PersonSchemaValidatorTest extends BaseCodegenTestCase {
     ]);
     $validator->validate();
 
-    expect($validator->isValid())->toBeFalse(
-      'should have failed with invalid friends age',
-    );
+    expect($validator->isValid())->toBeFalse('should have failed with invalid friends age');
   }
 
   public function testInvalidStringAndNumber(): void {
@@ -98,9 +89,7 @@ final class PersonSchemaValidatorTest extends BaseCodegenTestCase {
     ]);
     $validator->validate();
 
-    expect($validator->isValid())->toBeFalse(
-      'should require one string and one number',
-    );
+    expect($validator->isValid())->toBeFalse('should require one string and one number');
   }
 
   public function testValidStringAndNumber(): void {
@@ -177,9 +166,7 @@ final class PersonSchemaValidatorTest extends BaseCodegenTestCase {
     ]);
     $validator->validate();
 
-    expect($validator->isValid())->toBeTrue(
-      'should allow additional properties',
-    );
+    expect($validator->isValid())->toBeTrue('should allow additional properties');
 
     $validated = $validator->getValidatedInput();
     $devices = $validated['devices'] ?? null as nonnull;
@@ -188,10 +175,7 @@ final class PersonSchemaValidatorTest extends BaseCodegenTestCase {
     invariant(\is_array($device), 'device should be array');
 
     $extra = $device['extra'] ?? null;
-    expect($extra)->toBeSame(
-      true,
-      'additional properties should  be included in output',
-    );
+    expect($extra)->toBeSame(true, 'additional properties should  be included in output');
   }
 
   public function testDevicesPhoneValidAdditionalProperties(): void {
@@ -210,9 +194,7 @@ final class PersonSchemaValidatorTest extends BaseCodegenTestCase {
     ]);
     $validator->validate();
 
-    expect($validator->isValid())->toBeTrue(
-      'should allow additional properties that are strings',
-    );
+    expect($validator->isValid())->toBeTrue('should allow additional properties that are strings');
 
     $validated = $validator->getValidatedInput();
     $devices = $validated['devices'] ?? null as nonnull;
@@ -221,10 +203,7 @@ final class PersonSchemaValidatorTest extends BaseCodegenTestCase {
     invariant(\is_array($device), 'device should be array');
 
     $extra = $device['extra'] ?? null;
-    expect($extra)->toBeSame(
-      null,
-      "additional properties aren't set if other properties are defined",
-    );
+    expect($extra)->toBeSame(null, "additional properties aren't set if other properties are defined");
   }
 
   public function testDevicesPhoneInvalidAdditionalProperties(): void {
@@ -241,9 +220,7 @@ final class PersonSchemaValidatorTest extends BaseCodegenTestCase {
       ],
     ]);
     $validator->validate();
-    expect($validator->isValid())->toBeFalse(
-      "should not allow additional properties that aren't strings",
-    );
+    expect($validator->isValid())->toBeFalse("should not allow additional properties that aren't strings");
     expect(C\count($validator->getErrors()))->toBeSame(2);
   }
 
@@ -263,9 +240,7 @@ final class PersonSchemaValidatorTest extends BaseCodegenTestCase {
     ]);
     $validator->validate();
 
-    expect($validator->isValid())->toBeFalse(
-      'should be invalid phone number pattern',
-    );
+    expect($validator->isValid())->toBeFalse('should be invalid phone number pattern');
   }
 
   public function testValidStringOrNumber(): void {

--- a/tests/RefSchemaValidatorTest.php
+++ b/tests/RefSchemaValidatorTest.php
@@ -1,4 +1,4 @@
-<?hh // partial
+<?hh // strict
 
 namespace Slack\Hack\JsonSchema\Tests;
 

--- a/tests/StringSchemaValidatorTest.php
+++ b/tests/StringSchemaValidatorTest.php
@@ -1,4 +1,4 @@
-<?hh // partial
+<?hh // strict
 
 namespace Slack\Hack\JsonSchema\Tests;
 
@@ -26,12 +26,8 @@ final class StringSchemaValidatorTest extends BaseCodegenTestCase {
       'StringSchemaValidator',
       shape(
         'sanitize_string' => shape(
-          'uniline' => fun(
-            '\Slack\Hack\JsonSchema\Tests\_string_schema_validator_test_uniline',
-          ),
-          'multiline' => fun(
-            '\Slack\Hack\JsonSchema\Tests\_string_schema_validator_test_multiline',
-          ),
+          'uniline' => fun('\Slack\Hack\JsonSchema\Tests\_string_schema_validator_test_uniline'),
+          'multiline' => fun('\Slack\Hack\JsonSchema\Tests\_string_schema_validator_test_multiline'),
         ),
       ),
     );

--- a/tests/UntypedSchemaValidatorTest.php
+++ b/tests/UntypedSchemaValidatorTest.php
@@ -1,4 +1,4 @@
-<?hh // partial
+<?hh // strict
 
 namespace Slack\Hack\JsonSchema\Tests;
 
@@ -28,12 +28,8 @@ final class UntypedSchemaValidatorTest extends BaseCodegenTestCase {
       'UntypedSchemaValidator',
       shape(
         'sanitize_string' => shape(
-          'uniline' => fun(
-            '\Slack\Hack\JsonSchema\Tests\_untyped_schema_validator_test_uniline',
-          ),
-          'multiline' => fun(
-            '\Slack\Hack\JsonSchema\Tests\_untyped_schema_validator_test_multiline',
-          ),
+          'uniline' => fun('\Slack\Hack\JsonSchema\Tests\_untyped_schema_validator_test_uniline'),
+          'multiline' => fun('\Slack\Hack\JsonSchema\Tests\_untyped_schema_validator_test_multiline'),
         ),
       ),
     );
@@ -52,10 +48,7 @@ final class UntypedSchemaValidatorTest extends BaseCodegenTestCase {
     $validated_input = $validator->getValidatedInput();
     $any_of = ($validated_input['any_of'] ?? null) as nonnull;
 
-    Codegen\type_assert_shape(
-      $any_of,
-      'Slack\Hack\JsonSchema\Tests\Generated\TUntypedSchemaValidatorPropertiesAnyOf',
-    );
+    Codegen\type_assert_shape($any_of, 'Slack\Hack\JsonSchema\Tests\Generated\TUntypedSchemaValidatorPropertiesAnyOf');
   }
 
   public function testAllOf(): void {
@@ -89,9 +82,7 @@ final class UntypedSchemaValidatorTest extends BaseCodegenTestCase {
     $validator->validate();
 
     $validated = $validator->getValidatedInput();
-    expect($validated['all_of_pass_through'] ?? null)->toBeSame(
-      'some multiline string',
-    );
+    expect($validated['all_of_pass_through'] ?? null)->toBeSame('some multiline string');
   }
 
   public function testAllOfPassThroughSecondSchemaMutates(): void {
@@ -103,9 +94,7 @@ final class UntypedSchemaValidatorTest extends BaseCodegenTestCase {
     $validator->validate();
 
     $validated = $validator->getValidatedInput();
-    expect($validated['all_of_pass_through_second'] ?? null)->toBeSame(
-      'some multiline string',
-    );
+    expect($validated['all_of_pass_through_second'] ?? null)->toBeSame('some multiline string');
   }
 
   public function testAllOfCoerce(): void {
@@ -117,9 +106,7 @@ final class UntypedSchemaValidatorTest extends BaseCodegenTestCase {
     $validator->validate();
 
     $validated = $validator->getValidatedInput();
-    expect($validated['all_of_coerce'] ?? null)->toBeSame(
-      shape('property' => 'string value'),
-    );
+    expect($validated['all_of_coerce'] ?? null)->toBeSame(shape('property' => 'string value'));
   }
 
   public function testAllOfDefault(): void {
@@ -131,9 +118,7 @@ final class UntypedSchemaValidatorTest extends BaseCodegenTestCase {
     $validator->validate();
 
     $validated = $validator->getValidatedInput();
-    expect($validated['all_of_default'] ?? null)->toBeSame(
-      shape('numerical_property' => 0, 'property' => 'default'),
-    );
+    expect($validated['all_of_default'] ?? null)->toBeSame(shape('numerical_property' => 0, 'property' => 'default'));
   }
 
   public function testAllOfDefaultFirstSchemaWins(): void {


### PR DESCRIPTION
All the test files were marked as `// partial` before because the examples could not have been generated yet (since they're generated when unit tests are run) and previous versions of hhvm would fail to run them at all (thus never getting generated).

I tested this out and it doesn't seem to be an issue any more so marking these all as `// strict`