### PR TITLE
Handle `type` not being a string value like we expect

### DIFF
--- a/src/Codegen/Constraints/UntypedBuilder.php
+++ b/src/Codegen/Constraints/UntypedBuilder.php
@@ -430,11 +430,10 @@ class UntypedBuilder extends BaseBuilder<TUntypedSchema> {
       )
       ->ensureEmptyLine()
       ->addMultilineCall('Constraints\ObjectRequiredConstraint::check', vec['$typed', 'keyset[$key]', '$pointer'])
-      ->addAssignment('$type_name', '($typed[$key] ?? null) as nonnull', HackBuilderValues::literal())
       ->addAssignment('$field_pointer', 'JsonSchema\get_pointer($pointer, $key)', HackBuilderValues::literal())
       ->addAssignment(
         '$type_name',
-        'Constraints\StringConstraint::check($type_name, $field_pointer, false)',
+        'Constraints\StringConstraint::check($typed[$key] ?? null, $field_pointer, false)',
         HackBuilderValues::literal(),
       )
       ->ensureEmptyLine()

--- a/tests/UntypedSchemaValidatorTest.php
+++ b/tests/UntypedSchemaValidatorTest.php
@@ -163,4 +163,23 @@ final class UntypedSchemaValidatorTest extends BaseCodegenTestCase {
     expect($validator->isValid())->toBeFalse();
   }
 
+  public function testAnyOfOptimizedEnumInvalidType(): void {
+    $input = dict[
+      'any_of_optimized_enum' => dict[
+        'type' => null,
+        'integer' => 3,
+      ],
+    ];
+
+    $validator = new UntypedSchemaValidator($input);
+    $validator->validate();
+    expect($validator->isValid())->toBeFalse();
+    $errors = $validator->getErrors();
+    expect(C\count($errors))->toBeSame(1);
+    $error = $errors[0];
+    expect($error['code'])->toBeSame('invalid_type');
+    expect($error['message'])->toBeSame('must provide a string');
+    expect($error['pointer'] ?? null)->toBeSame('/any_of_optimized_enum/type');
+  }
+
 }

--- a/tests/examples/codegen/CustomCodegenConfigValidator.php
+++ b/tests/examples/codegen/CustomCodegenConfigValidator.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<359265246c578753e092aaac23c09040>>
+ * @generated SignedSource<<b091dd7814125f747984f31d8fafd43c>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;
@@ -649,10 +649,9 @@ final class CustomCodegenConfigValidatorPropertiesDevicesItems {
     $typed = Constraints\ObjectConstraint::check($input, $pointer, false);
 
     Constraints\ObjectRequiredConstraint::check($typed, keyset[$key], $pointer);
-    $type_name = ($typed[$key] ?? null) as nonnull;
     $field_pointer = JsonSchema\get_pointer($pointer, $key);
     $type_name =
-      Constraints\StringConstraint::check($type_name, $field_pointer, false);
+      Constraints\StringConstraint::check($typed[$key] ?? null, $field_pointer, false);
 
     $types = dict[
       'phone' =>

--- a/tests/examples/codegen/PersonSchemaValidator.php
+++ b/tests/examples/codegen/PersonSchemaValidator.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<386e40d994e41438a6cf7c899b5da3c1>>
+ * @generated SignedSource<<2ab2503832dc94e7486ad2834e8e40a5>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;
@@ -649,10 +649,9 @@ final class PersonSchemaValidatorPropertiesDevicesItems {
     $typed = Constraints\ObjectConstraint::check($input, $pointer, false);
 
     Constraints\ObjectRequiredConstraint::check($typed, keyset[$key], $pointer);
-    $type_name = ($typed[$key] ?? null) as nonnull;
     $field_pointer = JsonSchema\get_pointer($pointer, $key);
     $type_name =
-      Constraints\StringConstraint::check($type_name, $field_pointer, false);
+      Constraints\StringConstraint::check($typed[$key] ?? null, $field_pointer, false);
 
     $types = dict[
       'phone' =>

--- a/tests/examples/codegen/UntypedSchemaValidator.php
+++ b/tests/examples/codegen/UntypedSchemaValidator.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<3c498202f74829743c3f3d148c18ac0b>>
+ * @generated SignedSource<<0f9dda249bf4bf5215072b9e288a0fa5>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;
@@ -965,10 +965,9 @@ final class UntypedSchemaValidatorPropertiesAnyOfOptimizedEnum {
     $typed = Constraints\ObjectConstraint::check($input, $pointer, false);
 
     Constraints\ObjectRequiredConstraint::check($typed, keyset[$key], $pointer);
-    $type_name = ($typed[$key] ?? null) as nonnull;
     $field_pointer = JsonSchema\get_pointer($pointer, $key);
     $type_name =
-      Constraints\StringConstraint::check($type_name, $field_pointer, false);
+      Constraints\StringConstraint::check($typed[$key] ?? null, $field_pointer, false);
 
     $types = dict[
       'first' =>


### PR DESCRIPTION
Fix for: https://github.com/slackhq/hack-json-schema/issues/33