### PR TITLE
Support form-encoded uncoerced non-string arrays.

### DIFF
--- a/src/Constraints/ArrayConstraint.php
+++ b/src/Constraints/ArrayConstraint.php
@@ -22,7 +22,9 @@ class ArrayConstraint {
       // check to see if we can create an array from a comma delimited string.
       $valid_json = $coerced is nonnull && $coerced is Traversable<_>;
       if (!$valid_json) {
-        $coerced = Str\split($input, ',');
+        // Wrap in brackets and try JSON decoding again. This'll result in
+        // correctly typed output for non-string form encoded arrays.
+        $coerced = JsonSchema\json_decode_hack("[{$input}]");
       }
 
       $input = $coerced;

--- a/src/Constraints/ArrayConstraint.php
+++ b/src/Constraints/ArrayConstraint.php
@@ -2,7 +2,6 @@
 
 namespace Slack\Hack\JsonSchema\Constraints;
 
-use namespace HH\Lib\Str;
 use type Facebook\TypeAssert\{TypeCoercionException};
 use namespace Facebook\TypeSpec;
 use namespace Slack\Hack\JsonSchema;

--- a/tests/ArraySchemaValidatorTest.php
+++ b/tests/ArraySchemaValidatorTest.php
@@ -129,4 +129,43 @@ final class ArraySchemaValidatorTest extends BaseCodegenTestCase {
     expect($validated)->toBeSame(shape('coerce_array' => $input));
   }
 
+  public function testCoerceArrayOfUncoercedIntegersValidString(): void {
+    $input = vec[1, 2, 3, 4];
+
+    $validator = new ArraySchemaValidator(dict[
+      'coerce_array_of_uncoerced_integers' => \json_encode($input),
+    ]);
+    $validator->validate();
+
+    expect($validator->isValid())->toBeTrue();
+    $validated = $validator->getValidatedInput();
+
+    expect($validated)->toBeSame(shape('coerce_array_of_uncoerced_integers' => $input));
+  }
+
+  public function testCoerceArrayOfUncoercedIntegersInvalidString(): void {
+    $input = vec['1', '2', '3', '4'];
+
+    $validator = new ArraySchemaValidator(dict[
+      'coerce_array_of_uncoerced_integers' => \json_encode($input),
+    ]);
+    $validator->validate();
+
+    expect($validator->isValid())->toBeFalse();
+  }
+
+  public function testCoerceArrayOfUncoercedIntegersURLEncodedString(): void {
+    $input = vec[1, 2, 3, 4];
+
+    $validator = new ArraySchemaValidator(dict[
+      'coerce_array_of_uncoerced_integers' => Str\join($input, ','),
+    ]);
+    $validator->validate();
+
+    expect($validator->isValid())->toBeTrue();
+    $validated = $validator->getValidatedInput();
+
+    expect($validated)->toBeSame(shape('coerce_array_of_uncoerced_integers' => $input));
+  }
+
 }

--- a/tests/examples/array-schema.json
+++ b/tests/examples/array-schema.json
@@ -17,6 +17,13 @@
         "type": "number",
         "coerce": true
       }
+    },
+    "coerce_array_of_uncoerced_integers": {
+      "type": "array",
+      "coerce": true,
+      "items": {
+        "type": "integer"
+      }
     }
   }
 }

--- a/tests/examples/codegen/ArraySchemaValidator.php
+++ b/tests/examples/codegen/ArraySchemaValidator.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<14484ee6f8f738f12aee00444bbc398d>>
+ * @generated SignedSource<<df6e79084f583f4c3b613739bf647027>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;
@@ -15,6 +15,7 @@ type TArraySchemaValidator = shape(
   ?'array_of_strings' => vec<string>,
   ?'untyped_array' => vec<mixed>,
   ?'coerce_array' => vec<num>,
+  ?'coerce_array_of_uncoerced_integers' => vec<int>,
   ...
 );
 
@@ -109,6 +110,47 @@ final class ArraySchemaValidatorPropertiesCoerceArray {
   }
 }
 
+final class ArraySchemaValidatorPropertiesCoerceArrayOfUncoercedIntegersItems {
+
+  private static bool $coerce = false;
+
+  public static function check(mixed $input, string $pointer): int {
+    $typed =
+      Constraints\IntegerConstraint::check($input, $pointer, self::$coerce);
+
+    return $typed;
+  }
+}
+
+final class ArraySchemaValidatorPropertiesCoerceArrayOfUncoercedIntegers {
+
+  private static bool $coerce = true;
+
+  public static function check(mixed $input, string $pointer): vec<int> {
+    $typed = Constraints\ArrayConstraint::check($input, $pointer, self::$coerce);
+
+    $output = vec[];
+    $errors = vec[];
+
+    foreach ($typed as $index => $value) {
+      try {
+        $output[] = ArraySchemaValidatorPropertiesCoerceArrayOfUncoercedIntegersItems::check(
+          $value,
+          JsonSchema\get_pointer($pointer, (string) $index),
+        );
+      } catch (JsonSchema\InvalidFieldException $e) {
+        $errors = \HH\Lib\Vec\concat($errors, $e->errors);
+      }
+    }
+
+    if (\HH\Lib\C\count($errors)) {
+      throw new JsonSchema\InvalidFieldException($pointer, $errors);
+    }
+
+    return $output;
+  }
+}
+
 final class ArraySchemaValidator
   extends JsonSchema\BaseValidator<TArraySchemaValidator> {
 
@@ -156,6 +198,17 @@ final class ArraySchemaValidator
         $output['coerce_array'] = ArraySchemaValidatorPropertiesCoerceArray::check(
           $typed['coerce_array'],
           JsonSchema\get_pointer($pointer, 'coerce_array'),
+        );
+      } catch (JsonSchema\InvalidFieldException $e) {
+        $errors = \HH\Lib\Vec\concat($errors, $e->errors);
+      }
+    }
+
+    if (\HH\Lib\C\contains_key($typed, 'coerce_array_of_uncoerced_integers')) {
+      try {
+        $output['coerce_array_of_uncoerced_integers'] = ArraySchemaValidatorPropertiesCoerceArrayOfUncoercedIntegers::check(
+          $typed['coerce_array_of_uncoerced_integers'],
+          JsonSchema\get_pointer($pointer, 'coerce_array_of_uncoerced_integers'),
         );
       } catch (JsonSchema\InvalidFieldException $e) {
         $errors = \HH\Lib\Vec\concat($errors, $e->errors);


### PR DESCRIPTION
The existing `Str/split` results in string-typed output items, regardless of the format of the input items. If the item parsing is not performed in "coerced" mode, this will fail for non-string items.

Relying on `json_decode_hack` allows form-encoded uncoerced non-string arrays to be parsed as intended. This makes the behavior between json-encoded and form-encoded arrays consistent.