### PR TITLE
[Unblocking HHVM 4.56] Fixing HHVM_VERSION_ID for 4.47

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -13,9 +13,7 @@ function get_pointer(string $current, string ...$parts): string {
 
 function get_function_name_from_function(mixed $function): string {
   $func_name = '';
-
-  if (\HHVM_VERSION_ID >= 42100) {
-    /*HH_FIXME[2049]*//*HH_FIXME[4107] These errors don't apply in hhvm > 4.21*/
+  if (\version_compare(\HHVM_VERSION_ID, '4.21', '>=')) {
     $is_function = \is_callable_with_name($function, false, inout $func_name);
     invariant($is_function, 'You may only pass named functions to %s', __FUNCTION__);
   } else {

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -13,7 +13,7 @@ function get_pointer(string $current, string ...$parts): string {
 
 function get_function_name_from_function(mixed $function): string {
   $func_name = '';
-  if (\version_compare(\HHVM_VERSION_ID, '4.21', '>=')) {
+  if (\version_compare(\HHVM_VERSION, '4.21', '>=')) {
     $is_function = \is_callable_with_name($function, false, inout $func_name);
     invariant($is_function, 'You may only pass named functions to %s', __FUNCTION__);
   } else {


### PR DESCRIPTION
Information about 4.47 HHVM change [here](https://hhvm.com/blog/2020/03/03/hhvm-4.47.html).
vendor/slack/hack-json-schema/src/Utils.php: We are doing a check for HHVM_VERSION_ID using the old format, so I replace this with version_compare!