### PR TITLE
Revert "If a default is specified, the property should not be optional in the shape"

### DIFF
--- a/src/Codegen/Constraints/ObjectBuilder.php
+++ b/src/Codegen/Constraints/ObjectBuilder.php
@@ -395,7 +395,6 @@ class ObjectBuilder extends BaseBuilder<TObjectSchema> {
     return $hb;
   }
 
-  <<__Memoize>>
   private function getDefaults(): dict<string, mixed> {
     $properties = $this->typed_schema['properties'] ?? null;
     $defaults = dict[];
@@ -451,7 +450,6 @@ class ObjectBuilder extends BaseBuilder<TObjectSchema> {
     if ($property_classes is nonnull) {
       $required = $this->typed_schema['required'] ?? vec[];
       $additional_properties = $this->typed_schema['additionalProperties'] ?? null;
-      $defaults = $this->getDefaults();
 
       $allow_subtyping = $additional_properties is nonnull && $additional_properties is bool
         ? $additional_properties
@@ -460,7 +458,7 @@ class ObjectBuilder extends BaseBuilder<TObjectSchema> {
       $members = vec[];
       foreach ($property_classes as $property => $builder) {
         $member = new CodegenShapeMember($property, $builder->getType());
-        if (!C\contains($required, $property) && !C\contains_key($defaults, $property)) {
+        if (!C\contains($required, $property)) {
           $member->setIsOptional();
         }
 

--- a/tests/ObjectSchemaValidatorTest.php
+++ b/tests/ObjectSchemaValidatorTest.php
@@ -124,37 +124,6 @@ final class ObjectSchemaValidatorTest extends BaseCodegenTestCase {
     expect($property['S_string_value']['sample'])->toBeSame('test');
   }
 
-  public function testDefaultsDefaultValue(): void {
-    $validator = new ObjectSchemaValidator(dict[
-      'defaults' => dict[
-        'required_string' => 'string value',
-      ],
-    ]);
-
-    $validator->validate();
-    expect($validator->isValid())->toBeTrue();
-
-    $validated = $validator->getValidatedInput();
-    $defaults = $validated['defaults'] ?? null as nonnull;
-    expect($defaults['default_string'])->toBeSame('test');
-  }
-
-  public function testDefaultsProvideDefaultValue(): void {
-    $validator = new ObjectSchemaValidator(dict[
-      'defaults' => dict[
-        'required_string' => 'string value',
-        'default_string' => 'provided',
-      ],
-    ]);
-
-    $validator->validate();
-    expect($validator->isValid())->toBeTrue();
-
-    $validated = $validator->getValidatedInput();
-    $defaults = $validated['defaults'] ?? null as nonnull;
-    expect($defaults['default_string'])->toBeSame('provided');
-  }
-
   public function testOnlyPatternPropertiesValid(): void {
     $validator = new ObjectSchemaValidator(dict[
       'only_pattern_properties' => dict[

--- a/tests/examples/codegen/ObjectSchemaValidator.php
+++ b/tests/examples/codegen/ObjectSchemaValidator.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<fd534ebd94b67fe23410f2616abaa107>>
+ * @generated SignedSource<<766d50148a61a631dcd0c430fed23430>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;
@@ -16,14 +16,9 @@ type TObjectSchemaValidatorPropertiesOnlyAdditionalProperties = dict<string, mix
 type TObjectSchemaValidatorPropertiesOnlyNoAdditionalProperties = dict<string, mixed>;
 
 type TObjectSchemaValidatorPropertiesOnlyProperties = shape(
-  'string' => string,
-  'number' => num,
+  ?'string' => string,
+  ?'number' => num,
   'required_string' => string,
-);
-
-type TObjectSchemaValidatorPropertiesDefaults = shape(
-  'required_string' => string,
-  'default_string' => string,
 );
 
 type TObjectSchemaValidatorPropertiesOnlyPatternProperties = dict<string, mixed>;
@@ -93,7 +88,6 @@ type TObjectSchemaValidator = shape(
   ?'only_additional_properties' => TObjectSchemaValidatorPropertiesOnlyAdditionalProperties,
   ?'only_no_additional_properties' => TObjectSchemaValidatorPropertiesOnlyNoAdditionalProperties,
   ?'only_properties' => TObjectSchemaValidatorPropertiesOnlyProperties,
-  ?'defaults' => TObjectSchemaValidatorPropertiesDefaults,
   ?'only_pattern_properties' => TObjectSchemaValidatorPropertiesOnlyPatternProperties,
   ?'single_pattern_property_string' => TObjectSchemaValidatorPropertiesSinglePatternPropertyString,
   ?'single_pattern_property_object' => TObjectSchemaValidatorPropertiesSinglePatternPropertyObject,
@@ -251,106 +245,6 @@ final class ObjectSchemaValidatorPropertiesOnlyProperties {
         $output['required_string'] = ObjectSchemaValidatorPropertiesOnlyPropertiesPropertiesRequiredString::check(
           $typed['required_string'],
           JsonSchema\get_pointer($pointer, 'required_string'),
-        );
-      } catch (JsonSchema\InvalidFieldException $e) {
-        $errors = \HH\Lib\Vec\concat($errors, $e->errors);
-      }
-    }
-
-    /*HHAST_IGNORE_ERROR[UnusedVariable] Some loops generated with this statement do not use their $value*/
-    foreach ($typed as $key => $value) {
-      if (\HH\Lib\C\contains_key(self::$properties, $key)) {
-        continue;
-      }
-
-      $errors[] = shape(
-        'code' => JsonSchema\FieldErrorCode::FAILED_CONSTRAINT,
-        'message' => "invalid additional property: {$key}",
-        'constraint' => shape(
-          'type' => JsonSchema\FieldErrorConstraint::ADDITIONAL_PROPERTIES,
-          'got' => $key,
-        ),
-      );
-    }
-
-    if (\HH\Lib\C\count($errors)) {
-      throw new JsonSchema\InvalidFieldException($pointer, $errors);
-    }
-
-    /* HH_IGNORE_ERROR[4163] */
-    return $output;
-  }
-}
-
-final class ObjectSchemaValidatorPropertiesDefaultsPropertiesRequiredString {
-
-  private static bool $coerce = false;
-
-  public static function check(mixed $input, string $pointer): string {
-    $typed = Constraints\StringConstraint::check($input, $pointer, self::$coerce);
-
-    return $typed;
-  }
-}
-
-final class ObjectSchemaValidatorPropertiesDefaultsPropertiesDefaultString {
-
-  private static bool $coerce = false;
-
-  public static function check(mixed $input, string $pointer): string {
-    $typed = Constraints\StringConstraint::check($input, $pointer, self::$coerce);
-
-    return $typed;
-  }
-}
-
-final class ObjectSchemaValidatorPropertiesDefaults {
-
-  private static keyset<string> $required = keyset[
-    'required_string',
-  ];
-  private static bool $coerce = false;
-  private static keyset<string> $properties = keyset[
-    'required_string',
-    'default_string',
-  ];
-
-  public static function check(
-    mixed $input,
-    string $pointer,
-  ): TObjectSchemaValidatorPropertiesDefaults {
-    $typed = Constraints\ObjectConstraint::check($input, $pointer, self::$coerce);
-
-    $defaults = dict[
-      'default_string' => 'test',
-    ];
-    $typed = \HH\Lib\Dict\merge($defaults, $typed);
-
-    Constraints\ObjectRequiredConstraint::check(
-      $typed,
-      self::$required,
-      $pointer,
-    );
-
-    $errors = vec[];
-    $output = shape();
-
-    if (\HH\Lib\C\contains_key($typed, 'required_string')) {
-      try {
-        $output['required_string'] = ObjectSchemaValidatorPropertiesDefaultsPropertiesRequiredString::check(
-          $typed['required_string'],
-          JsonSchema\get_pointer($pointer, 'required_string'),
-        );
-      } catch (JsonSchema\InvalidFieldException $e) {
-        $errors = \HH\Lib\Vec\concat($errors, $e->errors);
-      }
-    }
-
-    if (\HH\Lib\C\contains_key($typed, 'default_string')) {
-      try {
-        $output['default_string'] = ObjectSchemaValidatorPropertiesDefaultsPropertiesDefaultString::check(
-          $typed['default_string'],
-          JsonSchema\get_pointer($pointer, 'default_string'),
         );
       } catch (JsonSchema\InvalidFieldException $e) {
         $errors = \HH\Lib\Vec\concat($errors, $e->errors);
@@ -1555,17 +1449,6 @@ final class ObjectSchemaValidator
         $output['only_properties'] = ObjectSchemaValidatorPropertiesOnlyProperties::check(
           $typed['only_properties'],
           JsonSchema\get_pointer($pointer, 'only_properties'),
-        );
-      } catch (JsonSchema\InvalidFieldException $e) {
-        $errors = \HH\Lib\Vec\concat($errors, $e->errors);
-      }
-    }
-
-    if (\HH\Lib\C\contains_key($typed, 'defaults')) {
-      try {
-        $output['defaults'] = ObjectSchemaValidatorPropertiesDefaults::check(
-          $typed['defaults'],
-          JsonSchema\get_pointer($pointer, 'defaults'),
         );
       } catch (JsonSchema\InvalidFieldException $e) {
         $errors = \HH\Lib\Vec\concat($errors, $e->errors);

--- a/tests/examples/codegen/UntypedSchemaValidator.php
+++ b/tests/examples/codegen/UntypedSchemaValidator.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<9b56eeba365dbe20f14089dfd10e3b57>>
+ * @generated SignedSource<<2b4426bd8e81874c4012b0c5fca9082c>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;
@@ -29,24 +29,24 @@ type TUntypedSchemaValidatorPropertiesAllOfCoerceAllOf1 = shape(
 type TUntypedSchemaValidatorPropertiesAllOfCoerce = mixed;
 
 type TUntypedSchemaValidatorPropertiesAllOfDefaultAllOf0 = shape(
-  'property' => string,
+  ?'property' => string,
   ...
 );
 
 type TUntypedSchemaValidatorPropertiesAllOfDefaultAllOf1 = shape(
-  'numerical_property' => num,
+  ?'numerical_property' => num,
   ...
 );
 
 type TUntypedSchemaValidatorPropertiesAllOfDefault = mixed;
 
 type TUntypedSchemaValidatorPropertiesAllOfDefaultFirstSchemaWinsAllOf0 = shape(
-  'property' => string,
+  ?'property' => string,
   ...
 );
 
 type TUntypedSchemaValidatorPropertiesAllOfDefaultFirstSchemaWinsAllOf1 = shape(
-  'property' => string,
+  ?'property' => string,
   ...
 );
 

--- a/tests/examples/object-schema.json
+++ b/tests/examples/object-schema.json
@@ -19,20 +19,6 @@
         "required_string": { "type": "string", "default": "required_default" }
       }
     },
-    "defaults": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["required_string"],
-      "properties": {
-        "required_string": {
-          "type": "string"
-        },
-        "default_string": {
-          "type": "string",
-          "default": "test"
-        }
-      }
-    },
     "only_pattern_properties": {
       "type": "object",
       "patternProperties": {


### PR DESCRIPTION
Reverts slackhq/hack-json-schema#41

I'm not sure about this change anymore. I thought it made sense because if you've defined a default, the property will always be there, but there is some conflict with how this works for our output schemas. Having a "default" for an output schema doesn't really make sense because we sample the validation of those outputs so the optional value actually makes more sense in that case.

I'm going to revert this since it hasn't been a pain point yet.