### PR TITLE
migrate class_meth to new function reference syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ SHELL := /bin/bash
 
 .PHONY: test autoload composer
 
-HHVM_VERSION=4.56.0
-HHVM_NEXT_VERSION=4.56.0
+HHVM_VERSION=4.80.5
+HHVM_NEXT_VERSION=4.80.5
 
 DOCKER_RUN=docker run -v $(shell pwd):/data --workdir /data --rm hhvm/hhvm:$(HHVM_VERSION)
 CONTAINER_NAME=hack-json-schema-hhvm

--- a/src/Codegen/Constraints/ArrayBuilder.php
+++ b/src/Codegen/Constraints/ArrayBuilder.php
@@ -199,7 +199,7 @@ class ArrayBuilder extends BaseBuilder<TArraySchema> {
       );
       $schema_builder->build();
 
-      $constraints[] = "class_meth({$schema_builder->getClassName()}::class, 'check')";
+      $constraints[] = "{$schema_builder->getClassName()}::check<>";
     }
 
     $hb

--- a/src/Codegen/Constraints/ObjectBuilder.php
+++ b/src/Codegen/Constraints/ObjectBuilder.php
@@ -232,7 +232,7 @@ class ObjectBuilder extends BaseBuilder<TObjectSchema> {
     if ($pattern_properties is nonnull) {
       $pattern_constraints = dict[];
       foreach ($pattern_properties as $pattern => $schema_builder) {
-        $pattern_constraints[$pattern] = "class_meth({$schema_builder->getClassName()}::class, 'check')";
+        $pattern_constraints[$pattern] = "{$schema_builder->getClassName()}::check<>";
       }
 
       $hb

--- a/src/Codegen/Constraints/UntypedBuilder.php
+++ b/src/Codegen/Constraints/UntypedBuilder.php
@@ -85,7 +85,7 @@ class UntypedBuilder extends BaseBuilder<TUntypedSchema> {
         $schema,
       );
       $schema_builder->build();
-      $constraints[] = "class_meth({$schema_builder->getClassName()}::class, 'check')";
+      $constraints[] = "{$schema_builder->getClassName()}::check<>";
     }
 
     $hb
@@ -140,7 +140,7 @@ class UntypedBuilder extends BaseBuilder<TUntypedSchema> {
         $schema,
       );
       $schema_builder->build();
-      $constraints[] = "class_meth({$schema_builder->getClassName()}::class, 'check')";
+      $constraints[] = "{$schema_builder->getClassName()}::check<>";
     }
 
     $hb
@@ -199,7 +199,7 @@ class UntypedBuilder extends BaseBuilder<TUntypedSchema> {
         $schema,
       );
       $schema_builder->build();
-      $constraints[] = "class_meth({$schema_builder->getClassName()}::class, 'check')";
+      $constraints[] = "{$schema_builder->getClassName()}::check<>";
     }
 
     $hb
@@ -340,7 +340,7 @@ class UntypedBuilder extends BaseBuilder<TUntypedSchema> {
   private function generateGenericAnyOfChecks(vec<SchemaBuilder> $schema_builders, HackBuilder $hb): void {
     $constraints = vec[];
     foreach ($schema_builders as $schema_builder) {
-      $constraints[] = "class_meth({$schema_builder->getClassName()}::class, 'check')";
+      $constraints[] = "{$schema_builder->getClassName()}::check<>";
     }
 
     // Checks for the special case of one null and one non-null type in order to
@@ -362,8 +362,7 @@ class UntypedBuilder extends BaseBuilder<TUntypedSchema> {
       if (C\count($without_null) === 1) {
         $non_null_schema_builder = $without_null[0];
 
-        $constraints = vec["class_meth({$non_null_schema_builder
-          ->getClassName()}::class, 'check')"];
+        $constraints = vec["{$non_null_schema_builder->getClassName()}::check<>"];
         $schema_builders = vec[$non_null_schema_builder];
 
         $hb
@@ -429,7 +428,7 @@ class UntypedBuilder extends BaseBuilder<TUntypedSchema> {
       $schema_builder->setSuffix($suffix);
       $schema_builder->build();
 
-      $types[$type_name] = "class_meth({$schema_builder->getClassName()}::class, 'check')";
+      $types[$type_name] = "{$schema_builder->getClassName()}::check<>";
     }
 
     $hb

--- a/tests/AnyOfRefiningTest.codegen
+++ b/tests/AnyOfRefiningTest.codegen
@@ -42,8 +42,8 @@ final class AnyOfValidator3 extends JsonSchema\BaseValidator<mixed> {
 
   public static function check(mixed $input, string $pointer): mixed {
     $constraints = vec[
-      class_meth(AnyOfValidator3AnyOf0::class, 'check'),
-      class_meth(AnyOfValidator3AnyOf1::class, 'check'),
+      AnyOfValidator3AnyOf0::check<>,
+      AnyOfValidator3AnyOf1::check<>,
     ];
 
     foreach ($constraints as $constraint) {
@@ -108,8 +108,8 @@ final class AnyOfValidator2 extends JsonSchema\BaseValidator<mixed> {
 
   public static function check(mixed $input, string $pointer): mixed {
     $constraints = vec[
-      class_meth(AnyOfValidator2AnyOf0::class, 'check'),
-      class_meth(AnyOfValidator2AnyOf1::class, 'check'),
+      AnyOfValidator2AnyOf0::check<>,
+      AnyOfValidator2AnyOf1::check<>,
     ];
 
     foreach ($constraints as $constraint) {
@@ -250,7 +250,7 @@ final class AnyOfValidator4 extends JsonSchema\BaseValidator<mixed> {
       return null;
     }
     $constraints = vec[
-      class_meth(AnyOfValidator4AnyOf1::class, 'check'),
+      AnyOfValidator4AnyOf1::check<>,
     ];
 
     foreach ($constraints as $constraint) {
@@ -308,7 +308,7 @@ final class AnyOfValidator1 extends JsonSchema\BaseValidator<mixed> {
       return null;
     }
     $constraints = vec[
-      class_meth(AnyOfValidator1AnyOf0::class, 'check'),
+      AnyOfValidator1AnyOf0::check<>,
     ];
 
     foreach ($constraints as $constraint) {

--- a/tests/CustomCodegenConfigTest.codegen
+++ b/tests/CustomCodegenConfigTest.codegen
@@ -262,8 +262,8 @@ final class CustomCodegenConfigValidatorPropertiesStringAndNumber {
     $output = vec[];
     $errors = vec[];
     $constraints = vec[
-      class_meth(CustomCodegenConfigValidatorItemsPropertiesStringAndNumber0::class, 'check'),
-      class_meth(CustomCodegenConfigValidatorItemsPropertiesStringAndNumber1::class, 'check'),
+      CustomCodegenConfigValidatorItemsPropertiesStringAndNumber0::check<>,
+      CustomCodegenConfigValidatorItemsPropertiesStringAndNumber1::check<>,
     ];
 
     foreach ($typed as $index => $value) {
@@ -554,9 +554,9 @@ final class CustomCodegenConfigValidatorPropertiesDevicesItems {
 
     $types = dict[
       'phone' =>
-        class_meth(CustomCodegenConfigValidatorPropertiesDevicesItemsOfTypesPhone::class, 'check'),
+        CustomCodegenConfigValidatorPropertiesDevicesItemsOfTypesPhone::check<>,
       'computer' =>
-        class_meth(CustomCodegenConfigValidatorPropertiesDevicesItemsOfTypesComputer::class, 'check'),
+        CustomCodegenConfigValidatorPropertiesDevicesItemsOfTypesComputer::check<>,
     ];
 
     $type_name = $typed[$key] ?? null;

--- a/tests/examples/codegen/AddressSchemaFileValidator.php
+++ b/tests/examples/codegen/AddressSchemaFileValidator.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<8912d020ee5f65e89b543788af6e132a>>
+ * @generated SignedSource<<484727a0001529079af389185ae513a4>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;

--- a/tests/examples/codegen/AddressSchemaFileValidator.php
+++ b/tests/examples/codegen/AddressSchemaFileValidator.php
@@ -316,8 +316,8 @@ final class AddressSchemaFileValidatorPropertiesPostalCode {
     string $pointer,
   ): TAddressSchemaFileValidatorPropertiesPostalCode {
     $constraints = vec[
-      class_meth(AddressSchemaFileValidatorPropertiesPostalCodeAnyOf0::class, 'check'),
-      class_meth(AddressSchemaFileValidatorPropertiesPostalCodeAnyOf1::class, 'check'),
+      AddressSchemaFileValidatorPropertiesPostalCodeAnyOf0::check<>,
+      AddressSchemaFileValidatorPropertiesPostalCodeAnyOf1::check<>,
     ];
     $errors = vec[
     ];

--- a/tests/examples/codegen/AddressSchemaValidator.php
+++ b/tests/examples/codegen/AddressSchemaValidator.php
@@ -237,8 +237,8 @@ final class AddressSchemaValidatorPropertiesPostalCode {
     string $pointer,
   ): TAddressSchemaValidatorPropertiesPostalCode {
     $constraints = vec[
-      class_meth(AddressSchemaValidatorPropertiesPostalCodeAnyOf0::class, 'check'),
-      class_meth(AddressSchemaValidatorPropertiesPostalCodeAnyOf1::class, 'check'),
+      AddressSchemaValidatorPropertiesPostalCodeAnyOf0::check<>,
+      AddressSchemaValidatorPropertiesPostalCodeAnyOf1::check<>,
     ];
     $errors = vec[
     ];
@@ -296,8 +296,8 @@ final class AddressSchemaValidatorPropertiesSize {
     string $pointer,
   ): TAddressSchemaValidatorPropertiesSize {
     $constraints = vec[
-      class_meth(AddressSchemaValidatorPropertiesSizeAllOf0::class, 'check'),
-      class_meth(AddressSchemaValidatorPropertiesSizeAllOf1::class, 'check'),
+      AddressSchemaValidatorPropertiesSizeAllOf0::check<>,
+      AddressSchemaValidatorPropertiesSizeAllOf1::check<>,
     ];
 
     $failed_any = false;
@@ -360,8 +360,8 @@ final class AddressSchemaValidatorPropertiesLongitude {
     string $pointer,
   ): TAddressSchemaValidatorPropertiesLongitude {
     $constraints = vec[
-      class_meth(AddressSchemaValidatorPropertiesLongitudeNot0::class, 'check'),
-      class_meth(AddressSchemaValidatorPropertiesLongitudeNot1::class, 'check'),
+      AddressSchemaValidatorPropertiesLongitudeNot0::check<>,
+      AddressSchemaValidatorPropertiesLongitudeNot1::check<>,
     ];
 
     $passed_any = false;
@@ -419,8 +419,8 @@ final class AddressSchemaValidatorPropertiesLatitude {
     string $pointer,
   ): TAddressSchemaValidatorPropertiesLatitude {
     $constraints = vec[
-      class_meth(AddressSchemaValidatorPropertiesLatitudeOneOf0::class, 'check'),
-      class_meth(AddressSchemaValidatorPropertiesLatitudeOneOf1::class, 'check'),
+      AddressSchemaValidatorPropertiesLatitudeOneOf0::check<>,
+      AddressSchemaValidatorPropertiesLatitudeOneOf1::check<>,
     ];
 
     $passed_any = false;

--- a/tests/examples/codegen/AddressSchemaValidator.php
+++ b/tests/examples/codegen/AddressSchemaValidator.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<c210a5de8764e578482ea9b79924c58d>>
+ * @generated SignedSource<<8e911409a784ef7ec27497da5a725588>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;

--- a/tests/examples/codegen/AnyOfValidator1.php
+++ b/tests/examples/codegen/AnyOfValidator1.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<4e84f337d3cc89a7383dad27397e22ec>>
+ * @generated SignedSource<<391bf4e73c2bf69b0a422bbae9f08261>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;

--- a/tests/examples/codegen/AnyOfValidator1.php
+++ b/tests/examples/codegen/AnyOfValidator1.php
@@ -35,7 +35,7 @@ final class AnyOfValidator1 extends JsonSchema\BaseValidator<TAnyOfValidator1> {
     }
 
     $constraints = vec[
-      class_meth(AnyOfValidator1AnyOf0::class, 'check'),
+      AnyOfValidator1AnyOf0::check<>,
     ];
     $errors = vec[
     ];

--- a/tests/examples/codegen/AnyOfValidator2.php
+++ b/tests/examples/codegen/AnyOfValidator2.php
@@ -42,8 +42,8 @@ final class AnyOfValidator2 extends JsonSchema\BaseValidator<TAnyOfValidator2> {
     string $pointer,
   ): TAnyOfValidator2 {
     $constraints = vec[
-      class_meth(AnyOfValidator2AnyOf0::class, 'check'),
-      class_meth(AnyOfValidator2AnyOf1::class, 'check'),
+      AnyOfValidator2AnyOf0::check<>,
+      AnyOfValidator2AnyOf1::check<>,
     ];
     $errors = vec[
     ];

--- a/tests/examples/codegen/AnyOfValidator2.php
+++ b/tests/examples/codegen/AnyOfValidator2.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<e9d93d2981719430d2dcb6386e728381>>
+ * @generated SignedSource<<72449b6279d0ca5b12355b69be8582b1>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;

--- a/tests/examples/codegen/AnyOfValidator3.php
+++ b/tests/examples/codegen/AnyOfValidator3.php
@@ -38,8 +38,8 @@ final class AnyOfValidator3 extends JsonSchema\BaseValidator<TAnyOfValidator3> {
     string $pointer,
   ): TAnyOfValidator3 {
     $constraints = vec[
-      class_meth(AnyOfValidator3AnyOf0::class, 'check'),
-      class_meth(AnyOfValidator3AnyOf1::class, 'check'),
+      AnyOfValidator3AnyOf0::check<>,
+      AnyOfValidator3AnyOf1::check<>,
     ];
     $errors = vec[
     ];

--- a/tests/examples/codegen/AnyOfValidator3.php
+++ b/tests/examples/codegen/AnyOfValidator3.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<8bc454a23d90e0e9e09f6ea74072bc5f>>
+ * @generated SignedSource<<f75639f4e8e44660c38760a9b0e53aa6>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;

--- a/tests/examples/codegen/AnyOfValidator4.php
+++ b/tests/examples/codegen/AnyOfValidator4.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<1bfa039408ec56218d92ea8195a00d66>>
+ * @generated SignedSource<<d09d51631fc44887137258196e936da6>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;

--- a/tests/examples/codegen/AnyOfValidator4.php
+++ b/tests/examples/codegen/AnyOfValidator4.php
@@ -125,7 +125,7 @@ final class AnyOfValidator4 extends JsonSchema\BaseValidator<TAnyOfValidator4> {
     }
 
     $constraints = vec[
-      class_meth(AnyOfValidator4AnyOf1::class, 'check'),
+      AnyOfValidator4AnyOf1::check<>,
     ];
     $errors = vec[
     ];

--- a/tests/examples/codegen/CustomCodegenConfigValidator.php
+++ b/tests/examples/codegen/CustomCodegenConfigValidator.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<e76c0d6ceb54c1359eedaf5650e32126>>
+ * @generated SignedSource<<e839a5cf76cbc60c3da1a15b9eb5ff3d>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;

--- a/tests/examples/codegen/CustomCodegenConfigValidator.php
+++ b/tests/examples/codegen/CustomCodegenConfigValidator.php
@@ -117,8 +117,8 @@ final class CustomCodegenConfigValidatorPropertiesStringOrNum {
     string $pointer,
   ): custom_codegen_config_validator_properties_string_or_num_t {
     $constraints = vec[
-      class_meth(CustomCodegenConfigValidatorPropertiesStringOrNumAnyOf0::class, 'check'),
-      class_meth(CustomCodegenConfigValidatorPropertiesStringOrNumAnyOf1::class, 'check'),
+      CustomCodegenConfigValidatorPropertiesStringOrNumAnyOf0::check<>,
+      CustomCodegenConfigValidatorPropertiesStringOrNumAnyOf1::check<>,
     ];
     $errors = vec[
     ];
@@ -335,8 +335,8 @@ final class CustomCodegenConfigValidatorPropertiesStringAndNumber {
     $output = vec[];
     $errors = vec[];
     $constraints = vec[
-      class_meth(CustomCodegenConfigValidatorItemsPropertiesStringAndNumber0::class, 'check'),
-      class_meth(CustomCodegenConfigValidatorItemsPropertiesStringAndNumber1::class, 'check'),
+      CustomCodegenConfigValidatorItemsPropertiesStringAndNumber0::check<>,
+      CustomCodegenConfigValidatorItemsPropertiesStringAndNumber1::check<>,
     ];
 
     foreach ($typed as $index => $value) {
@@ -655,9 +655,9 @@ final class CustomCodegenConfigValidatorPropertiesDevicesItems {
 
     $types = dict[
       'phone' =>
-        class_meth(CustomCodegenConfigValidatorPropertiesDevicesItemsAnyOfTypesPhone::class, 'check'),
+        CustomCodegenConfigValidatorPropertiesDevicesItemsAnyOfTypesPhone::check<>,
       'computer' =>
-        class_meth(CustomCodegenConfigValidatorPropertiesDevicesItemsAnyOfTypesComputer::class, 'check'),
+        CustomCodegenConfigValidatorPropertiesDevicesItemsAnyOfTypesComputer::check<>,
     ];
 
     $constraint = $types[$type_name] ?? null;

--- a/tests/examples/codegen/FriendsSchemaValidator.php
+++ b/tests/examples/codegen/FriendsSchemaValidator.php
@@ -225,8 +225,8 @@ final class FriendsSchemaValidatorItemsPropertiesRating {
     $output = vec[];
     $errors = vec[];
     $constraints = vec[
-      class_meth(FriendsSchemaValidatorItemsItemsPropertiesRating0::class, 'check'),
-      class_meth(FriendsSchemaValidatorItemsItemsPropertiesRating1::class, 'check'),
+      FriendsSchemaValidatorItemsItemsPropertiesRating0::check<>,
+      FriendsSchemaValidatorItemsItemsPropertiesRating1::check<>,
     ];
 
     foreach ($typed as $index => $value) {
@@ -290,8 +290,8 @@ final class FriendsSchemaValidatorItemsPropertiesContact {
     $output = vec[];
     $errors = vec[];
     $constraints = vec[
-      class_meth(FriendsSchemaValidatorItemsItemsPropertiesContact0::class, 'check'),
-      class_meth(FriendsSchemaValidatorItemsItemsPropertiesContact1::class, 'check'),
+      FriendsSchemaValidatorItemsItemsPropertiesContact0::check<>,
+      FriendsSchemaValidatorItemsItemsPropertiesContact1::check<>,
     ];
 
     foreach ($typed as $index => $value) {

--- a/tests/examples/codegen/FriendsSchemaValidator.php
+++ b/tests/examples/codegen/FriendsSchemaValidator.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<71da10c4b1e8d8797b14b9323a036a8e>>
+ * @generated SignedSource<<c1e1a034a097914b540fefaa46b64ab6>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;

--- a/tests/examples/codegen/ObjectSchemaValidator.php
+++ b/tests/examples/codegen/ObjectSchemaValidator.php
@@ -420,9 +420,9 @@ final class ObjectSchemaValidatorPropertiesOnlyPatternProperties {
 
     $patterns = dict[
       '^S_' =>
-        class_meth(ObjectSchemaValidatorPropertiesOnlyPatternPropertiesPatternProperties0::class, 'check'),
+        ObjectSchemaValidatorPropertiesOnlyPatternPropertiesPatternProperties0::check<>,
       '^I_' =>
-        class_meth(ObjectSchemaValidatorPropertiesOnlyPatternPropertiesPatternProperties1::class, 'check'),
+        ObjectSchemaValidatorPropertiesOnlyPatternPropertiesPatternProperties1::check<>,
     ];
 
     /*HHAST_IGNORE_ERROR[UnusedVariable] Some loops generated with this statement do not use their $value*/
@@ -490,7 +490,7 @@ final class ObjectSchemaValidatorPropertiesSinglePatternPropertyString {
 
     $patterns = dict[
       '^S_' =>
-        class_meth(ObjectSchemaValidatorPropertiesSinglePatternPropertyStringPatternProperties0::class, 'check'),
+        ObjectSchemaValidatorPropertiesSinglePatternPropertyStringPatternProperties0::check<>,
     ];
 
     /*HHAST_IGNORE_ERROR[UnusedVariable] Some loops generated with this statement do not use their $value*/
@@ -605,7 +605,7 @@ final class ObjectSchemaValidatorPropertiesSinglePatternPropertyObject {
 
     $patterns = dict[
       '^S_' =>
-        class_meth(ObjectSchemaValidatorPropertiesSinglePatternPropertyObjectPatternProperties0::class, 'check'),
+        ObjectSchemaValidatorPropertiesSinglePatternPropertyObjectPatternProperties0::check<>,
     ];
 
     /*HHAST_IGNORE_ERROR[UnusedVariable] Some loops generated with this statement do not use their $value*/
@@ -684,9 +684,9 @@ final class ObjectSchemaValidatorPropertiesPatternPropertiesNoAdditionalProperti
 
     $patterns = dict[
       '^S_' =>
-        class_meth(ObjectSchemaValidatorPropertiesPatternPropertiesNoAdditionalPropertiesPatternProperties0::class, 'check'),
+        ObjectSchemaValidatorPropertiesPatternPropertiesNoAdditionalPropertiesPatternProperties0::check<>,
       '^I_' =>
-        class_meth(ObjectSchemaValidatorPropertiesPatternPropertiesNoAdditionalPropertiesPatternProperties1::class, 'check'),
+        ObjectSchemaValidatorPropertiesPatternPropertiesNoAdditionalPropertiesPatternProperties1::check<>,
     ];
 
     /*HHAST_IGNORE_ERROR[UnusedVariable] Some loops generated with this statement do not use their $value*/
@@ -803,9 +803,9 @@ final class ObjectSchemaValidatorPropertiesPropertiesAndPatternProperties {
 
     $patterns = dict[
       '^S_' =>
-        class_meth(ObjectSchemaValidatorPropertiesPropertiesAndPatternPropertiesPatternProperties0::class, 'check'),
+        ObjectSchemaValidatorPropertiesPropertiesAndPatternPropertiesPatternProperties0::check<>,
       '^I_' =>
-        class_meth(ObjectSchemaValidatorPropertiesPropertiesAndPatternPropertiesPatternProperties1::class, 'check'),
+        ObjectSchemaValidatorPropertiesPropertiesAndPatternPropertiesPatternProperties1::check<>,
     ];
 
     /*HHAST_IGNORE_ERROR[UnusedVariable] Some loops generated with this statement do not use their $value*/
@@ -910,9 +910,9 @@ final class ObjectSchemaValidatorPropertiesPropertiesAndPatternPropertiesNoAddit
 
     $patterns = dict[
       '^S_' =>
-        class_meth(ObjectSchemaValidatorPropertiesPropertiesAndPatternPropertiesNoAdditionalPatternProperties0::class, 'check'),
+        ObjectSchemaValidatorPropertiesPropertiesAndPatternPropertiesNoAdditionalPatternProperties0::check<>,
       '^I_' =>
-        class_meth(ObjectSchemaValidatorPropertiesPropertiesAndPatternPropertiesNoAdditionalPatternProperties1::class, 'check'),
+        ObjectSchemaValidatorPropertiesPropertiesAndPatternPropertiesNoAdditionalPatternProperties1::check<>,
     ];
 
     /*HHAST_IGNORE_ERROR[UnusedVariable] Some loops generated with this statement do not use their $value*/

--- a/tests/examples/codegen/ObjectSchemaValidator.php
+++ b/tests/examples/codegen/ObjectSchemaValidator.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<fd534ebd94b67fe23410f2616abaa107>>
+ * @generated SignedSource<<4dc1f7d0a726caf2a6f79d0ee597cb2a>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;

--- a/tests/examples/codegen/PersonSchemaValidator.php
+++ b/tests/examples/codegen/PersonSchemaValidator.php
@@ -117,8 +117,8 @@ final class PersonSchemaValidatorPropertiesStringOrNum {
     string $pointer,
   ): TPersonSchemaValidatorPropertiesStringOrNum {
     $constraints = vec[
-      class_meth(PersonSchemaValidatorPropertiesStringOrNumAnyOf0::class, 'check'),
-      class_meth(PersonSchemaValidatorPropertiesStringOrNumAnyOf1::class, 'check'),
+      PersonSchemaValidatorPropertiesStringOrNumAnyOf0::check<>,
+      PersonSchemaValidatorPropertiesStringOrNumAnyOf1::check<>,
     ];
     $errors = vec[
     ];
@@ -335,8 +335,8 @@ final class PersonSchemaValidatorPropertiesStringAndNumber {
     $output = vec[];
     $errors = vec[];
     $constraints = vec[
-      class_meth(PersonSchemaValidatorItemsPropertiesStringAndNumber0::class, 'check'),
-      class_meth(PersonSchemaValidatorItemsPropertiesStringAndNumber1::class, 'check'),
+      PersonSchemaValidatorItemsPropertiesStringAndNumber0::check<>,
+      PersonSchemaValidatorItemsPropertiesStringAndNumber1::check<>,
     ];
 
     foreach ($typed as $index => $value) {
@@ -655,9 +655,9 @@ final class PersonSchemaValidatorPropertiesDevicesItems {
 
     $types = dict[
       'phone' =>
-        class_meth(PersonSchemaValidatorPropertiesDevicesItemsAnyOfTypesPhone::class, 'check'),
+        PersonSchemaValidatorPropertiesDevicesItemsAnyOfTypesPhone::check<>,
       'computer' =>
-        class_meth(PersonSchemaValidatorPropertiesDevicesItemsAnyOfTypesComputer::class, 'check'),
+        PersonSchemaValidatorPropertiesDevicesItemsAnyOfTypesComputer::check<>,
     ];
 
     $constraint = $types[$type_name] ?? null;

--- a/tests/examples/codegen/PersonSchemaValidator.php
+++ b/tests/examples/codegen/PersonSchemaValidator.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<69e5cb53412ae40a0dd69480b9e95303>>
+ * @generated SignedSource<<29a06b2c6c94a2e1969280850f23e6ed>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;

--- a/tests/examples/codegen/RefSchemaValidator.php
+++ b/tests/examples/codegen/RefSchemaValidator.php
@@ -45,7 +45,7 @@ final class RefSchemaValidatorPropertiesNullableUniqueRef {
     }
 
     $constraints = vec[
-      class_meth(ExternalExamplesRefSchemaDefinitionsObject::class, 'check'),
+      ExternalExamplesRefSchemaDefinitionsObject::check<>,
     ];
     $errors = vec[
     ];

--- a/tests/examples/codegen/RefSchemaValidator.php
+++ b/tests/examples/codegen/RefSchemaValidator.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<97f9b4529d3339d01c5b566623068f8f>>
+ * @generated SignedSource<<98eaf6ad9c7dad3c90928ea79b70f4e7>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;

--- a/tests/examples/codegen/UntypedSchemaValidator.php
+++ b/tests/examples/codegen/UntypedSchemaValidator.php
@@ -106,8 +106,8 @@ final class UntypedSchemaValidatorPropertiesAllOf {
     string $pointer,
   ): TUntypedSchemaValidatorPropertiesAllOf {
     $constraints = vec[
-      class_meth(UntypedSchemaValidatorPropertiesAllOfAllOf0::class, 'check'),
-      class_meth(UntypedSchemaValidatorPropertiesAllOfAllOf1::class, 'check'),
+      UntypedSchemaValidatorPropertiesAllOfAllOf0::check<>,
+      UntypedSchemaValidatorPropertiesAllOfAllOf1::check<>,
     ];
 
     $failed_any = false;
@@ -170,8 +170,8 @@ final class UntypedSchemaValidatorPropertiesAnyOf {
     string $pointer,
   ): TUntypedSchemaValidatorPropertiesAnyOf {
     $constraints = vec[
-      class_meth(UntypedSchemaValidatorPropertiesAnyOfAnyOf0::class, 'check'),
-      class_meth(UntypedSchemaValidatorPropertiesAnyOfAnyOf1::class, 'check'),
+      UntypedSchemaValidatorPropertiesAnyOfAnyOf0::check<>,
+      UntypedSchemaValidatorPropertiesAnyOfAnyOf1::check<>,
     ];
     $errors = vec[
     ];
@@ -239,8 +239,8 @@ final class UntypedSchemaValidatorPropertiesAllOfPassThrough {
     string $pointer,
   ): TUntypedSchemaValidatorPropertiesAllOfPassThrough {
     $constraints = vec[
-      class_meth(UntypedSchemaValidatorPropertiesAllOfPassThroughAllOf0::class, 'check'),
-      class_meth(UntypedSchemaValidatorPropertiesAllOfPassThroughAllOf1::class, 'check'),
+      UntypedSchemaValidatorPropertiesAllOfPassThroughAllOf0::check<>,
+      UntypedSchemaValidatorPropertiesAllOfPassThroughAllOf1::check<>,
     ];
 
     $failed_any = false;
@@ -310,8 +310,8 @@ final class UntypedSchemaValidatorPropertiesAllOfPassThroughSecond {
     string $pointer,
   ): TUntypedSchemaValidatorPropertiesAllOfPassThroughSecond {
     $constraints = vec[
-      class_meth(UntypedSchemaValidatorPropertiesAllOfPassThroughSecondAllOf0::class, 'check'),
-      class_meth(UntypedSchemaValidatorPropertiesAllOfPassThroughSecondAllOf1::class, 'check'),
+      UntypedSchemaValidatorPropertiesAllOfPassThroughSecondAllOf0::check<>,
+      UntypedSchemaValidatorPropertiesAllOfPassThroughSecondAllOf1::check<>,
     ];
 
     $failed_any = false;
@@ -418,8 +418,8 @@ final class UntypedSchemaValidatorPropertiesAllOfCoerce {
     string $pointer,
   ): TUntypedSchemaValidatorPropertiesAllOfCoerce {
     $constraints = vec[
-      class_meth(UntypedSchemaValidatorPropertiesAllOfCoerceAllOf0::class, 'check'),
-      class_meth(UntypedSchemaValidatorPropertiesAllOfCoerceAllOf1::class, 'check'),
+      UntypedSchemaValidatorPropertiesAllOfCoerceAllOf0::check<>,
+      UntypedSchemaValidatorPropertiesAllOfCoerceAllOf1::check<>,
     ];
 
     $failed_any = false;
@@ -571,8 +571,8 @@ final class UntypedSchemaValidatorPropertiesAllOfDefault {
     string $pointer,
   ): TUntypedSchemaValidatorPropertiesAllOfDefault {
     $constraints = vec[
-      class_meth(UntypedSchemaValidatorPropertiesAllOfDefaultAllOf0::class, 'check'),
-      class_meth(UntypedSchemaValidatorPropertiesAllOfDefaultAllOf1::class, 'check'),
+      UntypedSchemaValidatorPropertiesAllOfDefaultAllOf0::check<>,
+      UntypedSchemaValidatorPropertiesAllOfDefaultAllOf1::check<>,
     ];
 
     $failed_any = false;
@@ -724,8 +724,8 @@ final class UntypedSchemaValidatorPropertiesAllOfDefaultFirstSchemaWins {
     string $pointer,
   ): TUntypedSchemaValidatorPropertiesAllOfDefaultFirstSchemaWins {
     $constraints = vec[
-      class_meth(UntypedSchemaValidatorPropertiesAllOfDefaultFirstSchemaWinsAllOf0::class, 'check'),
-      class_meth(UntypedSchemaValidatorPropertiesAllOfDefaultFirstSchemaWinsAllOf1::class, 'check'),
+      UntypedSchemaValidatorPropertiesAllOfDefaultFirstSchemaWinsAllOf0::check<>,
+      UntypedSchemaValidatorPropertiesAllOfDefaultFirstSchemaWinsAllOf1::check<>,
     ];
 
     $failed_any = false;
@@ -971,9 +971,9 @@ final class UntypedSchemaValidatorPropertiesAnyOfOptimizedEnum {
 
     $types = dict[
       'first' =>
-        class_meth(UntypedSchemaValidatorPropertiesAnyOfOptimizedEnumAnyOfTypesFirst::class, 'check'),
+        UntypedSchemaValidatorPropertiesAnyOfOptimizedEnumAnyOfTypesFirst::check<>,
       'second' =>
-        class_meth(UntypedSchemaValidatorPropertiesAnyOfOptimizedEnumAnyOfTypesSecond::class, 'check'),
+        UntypedSchemaValidatorPropertiesAnyOfOptimizedEnumAnyOfTypesSecond::check<>,
     ];
 
     $constraint = $types[$type_name] ?? null;

--- a/tests/examples/codegen/UntypedSchemaValidator.php
+++ b/tests/examples/codegen/UntypedSchemaValidator.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<9b56eeba365dbe20f14089dfd10e3b57>>
+ * @generated SignedSource<<5386112b2408967d5cdecac56bc4d40e>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;


### PR DESCRIPTION
The `class_meth` function will be removed from HHVM soon (see https://hhvm.com/blog/2020/11/10/hhvm-4.83.html). This migrates this codegen to use the new syntax instead.