### PR TITLE
Remove ArrayConstraint coercion that supported PHP and Hack arrays

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,10 +8,10 @@ jobs:
       # Run tests on all OS's and HHVM versions, even if one fails
       fail-fast: false
       matrix:
-        os: [ ubuntu ]
+        os: [ubuntu]
         hhvm:
-          - '4.80'
-          - '4.102'
+          - "4.102"
+          - "4.128"
     runs-on: ${{matrix.os}}-latest
     steps:
       - uses: actions/checkout@v2

--- a/src/Constraints/ArrayConstraint.php
+++ b/src/Constraints/ArrayConstraint.php
@@ -3,7 +3,6 @@
 namespace Slack\Hack\JsonSchema\Constraints;
 
 use namespace HH\Lib\Str;
-use type Facebook\TypeAssert\{TypeCoercionException};
 use namespace Facebook\{TypeAssert, TypeSpec};
 use namespace Slack\Hack\JsonSchema;
 

--- a/src/Constraints/ArrayConstraint.php
+++ b/src/Constraints/ArrayConstraint.php
@@ -4,7 +4,7 @@ namespace Slack\Hack\JsonSchema\Constraints;
 
 use namespace HH\Lib\Str;
 use type Facebook\TypeAssert\{TypeCoercionException};
-use namespace Facebook\TypeSpec;
+use namespace Facebook\{TypeAssert, TypeSpec};
 use namespace Slack\Hack\JsonSchema;
 
 class ArrayConstraint {
@@ -27,7 +27,7 @@ class ArrayConstraint {
     $spec = TypeSpec\vec(TypeSpec\mixed());
     try {
       return $spec->assertType($input);
-    } catch (TypeCoercionException $e) {
+    } catch (TypeAssert\IncorrectTypeException $e) {
       $error = shape(
         'code' => JsonSchema\FieldErrorCode::INVALID_TYPE,
         'message' => 'must provide an array',

--- a/src/Constraints/ArrayConstraint.php
+++ b/src/Constraints/ArrayConstraint.php
@@ -26,8 +26,7 @@ class ArrayConstraint {
 
     $spec = TypeSpec\vec(TypeSpec\mixed());
     try {
-      # To allow for either PHP or hack arrays, we coerce to a vec here.
-      return $spec->coerceType($input);
+      return $spec->assertType($input);
     } catch (TypeCoercionException $e) {
       $error = shape(
         'code' => JsonSchema\FieldErrorCode::INVALID_TYPE,

--- a/tests/ArraySchemaValidatorTest.php
+++ b/tests/ArraySchemaValidatorTest.php
@@ -39,9 +39,7 @@ final class ArraySchemaValidatorTest extends BaseCodegenTestCase {
     $validator = new ArraySchemaValidator(darray['array_of_strings' => varray['test', 'list', 'of', 'strings']]);
     $validator->validate();
 
-    expect($validator->isValid())->toBeTrue();
-    $validated = $validator->getValidatedInput();
-    expect(C\count($validated['array_of_strings'] ?? vec[]))->toBeSame(4);
+    expect($validator->isValid())->toBeFalse();
   }
 
   public function testArrayOfStringsLegacyAndHackArrays(): void {
@@ -50,22 +48,16 @@ final class ArraySchemaValidatorTest extends BaseCodegenTestCase {
     ]);
     $validator->validate();
 
-    expect($validator->isValid())->toBeTrue();
-    $validated = $validator->getValidatedInput();
-    expect(C\count($validated['array_of_strings'] ?? vec[]))->toBeSame(4);
+    expect($validator->isValid())->toBeFalse();
   }
 
-  public function testUntypedArrayValid(): void {
+  public function testDictOfStringsInvalid(): void {
     $validator = new ArraySchemaValidator(dict[
-      'untyped_array' => varray['test', 'values'],
+      'array_of_strings' => dict['test' => 'test'],
     ]);
     $validator->validate();
 
-    expect($validator->isValid())->toBeTrue();
-    $validated = $validator->getValidatedInput();
-
-    expect(Shapes::idx($validated, 'untyped_array') as nonnull[0])->toBeSame('test');
-    expect(Shapes::idx($validated, 'untyped_array') as nonnull[1])->toBeSame('values');
+    expect($validator->isValid())->toBeFalse();
   }
 
   public function testCoerceArrayValidString(): void {

--- a/tests/ArraySchemaValidatorTest.php
+++ b/tests/ArraySchemaValidatorTest.php
@@ -53,6 +53,19 @@ final class ArraySchemaValidatorTest extends BaseCodegenTestCase {
     expect($validator->isValid())->toBeFalse();
   }
 
+  public function testUntypedArrayValid(): void {
+    $validator = new ArraySchemaValidator(dict[
+      'untyped_array' => vec['test', 'values'],
+    ]);
+    $validator->validate();
+
+    expect($validator->isValid())->toBeTrue();
+    $validated = $validator->getValidatedInput();
+
+    expect(Shapes::idx($validated, 'untyped_array') as nonnull[0])->toBeSame('test');
+    expect(Shapes::idx($validated, 'untyped_array') as nonnull[1])->toBeSame('values');
+  }
+
   public function testCoerceArrayValidString(): void {
     $input = vec[1, 2, 3, 4];
 

--- a/tests/ArraySchemaValidatorTest.php
+++ b/tests/ArraySchemaValidatorTest.php
@@ -18,7 +18,7 @@ final class ArraySchemaValidatorTest extends BaseCodegenTestCase {
   }
 
   public function testArrayOfStringsInvalidRoot(): void {
-    $validator = new ArraySchemaValidator(varray['test', 'list', 'of', 'strings']);
+    $validator = new ArraySchemaValidator(vec['test', 'list', 'of', 'strings']);
     $validator->validate();
 
     expect($validator->isValid())->toBeFalse();
@@ -36,19 +36,12 @@ final class ArraySchemaValidatorTest extends BaseCodegenTestCase {
   }
 
   public function testArrayOfStringsLegacyArrays(): void {
-    $validator = new ArraySchemaValidator(darray['array_of_strings' => varray['test', 'list', 'of', 'strings']]);
+    $validator = new ArraySchemaValidator(darray['array_of_strings' => vec['test', 'list', 'of', 'strings']]);
     $validator->validate();
 
-    expect($validator->isValid())->toBeFalse();
-  }
-
-  public function testArrayOfStringsLegacyAndHackArrays(): void {
-    $validator = new ArraySchemaValidator(dict[
-      'array_of_strings' => varray['test', 'list', 'of', 'strings'],
-    ]);
-    $validator->validate();
-
-    expect($validator->isValid())->toBeFalse();
+    expect($validator->isValid())->toBeTrue();
+    $validated = $validator->getValidatedInput();
+    expect(C\count($validated['array_of_strings'] ?? vec[]))->toBeSame(4);
   }
 
   public function testDictOfStringsInvalid(): void {

--- a/tests/DiscardAddititionalPropertiesValidatorTest.php
+++ b/tests/DiscardAddititionalPropertiesValidatorTest.php
@@ -61,7 +61,7 @@ final class DiscardAddititionalPropertiesValidatorTest extends BaseCodegenTestCa
     $input = dict[
       'additional_properties_ref' => dict[
         'something' => dict[
-          'something-else' => varray['array', 'of', 'strings'],
+          'something-else' => vec['array', 'of', 'strings'],
         ],
       ],
     ];
@@ -73,7 +73,7 @@ final class DiscardAddititionalPropertiesValidatorTest extends BaseCodegenTestCa
     $input = dict[
       'additional_properties_ref' => dict[
         'something' => dict[
-          'something-else' => varray[34, 'of', 'strings'],
+          'something-else' => vec[34, 'of', 'strings'],
         ],
       ],
     ];

--- a/tests/ObjectSchemaValidatorTest.php
+++ b/tests/ObjectSchemaValidatorTest.php
@@ -486,7 +486,7 @@ final class ObjectSchemaValidatorTest extends BaseCodegenTestCase {
   public function testAdditionalProperitesArray(): void {
     $input = dict[
       'additional_properties_array' => dict[
-        'something' => varray['array', 'of', 'strings'],
+        'something' => vec['array', 'of', 'strings'],
       ],
     ];
 
@@ -496,7 +496,7 @@ final class ObjectSchemaValidatorTest extends BaseCodegenTestCase {
 
     $input = dict[
       'additional_properties_array' => dict[
-        'something' => varray[34, 'of', 'strings'],
+        'something' => vec[34, 'of', 'strings'],
       ],
     ];
 
@@ -509,7 +509,7 @@ final class ObjectSchemaValidatorTest extends BaseCodegenTestCase {
     $input = dict[
       'additional_properties_ref' => dict[
         'something' => dict[
-          'something-else' => varray['array', 'of', 'strings'],
+          'something-else' => vec['array', 'of', 'strings'],
         ],
       ],
     ];
@@ -521,7 +521,7 @@ final class ObjectSchemaValidatorTest extends BaseCodegenTestCase {
     $input = dict[
       'additional_properties_ref' => dict[
         'something' => dict[
-          'something-else' => varray[34, 'of', 'strings'],
+          'something-else' => vec[34, 'of', 'strings'],
         ],
       ],
     ];

--- a/tests/PersonSchemaValidatorTest.php
+++ b/tests/PersonSchemaValidatorTest.php
@@ -172,7 +172,7 @@ final class PersonSchemaValidatorTest extends BaseCodegenTestCase {
     $devices = $validated['devices'] ?? null as nonnull;
 
     $device = $devices[0];
-    invariant(\HH\is_php_array($device), 'device should be array');
+    invariant($device is AnyArray<_, _>, 'device should be array');
 
     $extra = $device['extra'] ?? null;
     expect($extra)->toBeSame(true, 'additional properties should  be included in output');
@@ -200,7 +200,7 @@ final class PersonSchemaValidatorTest extends BaseCodegenTestCase {
     $devices = $validated['devices'] ?? null as nonnull;
 
     $device = $devices[0];
-    invariant(\HH\is_php_array($device), 'device should be array');
+    invariant($device is AnyArray<_, _>, 'device should be array');
 
     $extra = $device['extra'] ?? null;
     expect($extra)->toBeSame(null, "additional properties aren't set if other properties are defined");

--- a/tests/RefSchemaValidatorTest.php
+++ b/tests/RefSchemaValidatorTest.php
@@ -64,7 +64,7 @@ final class RefSchemaValidatorTest extends BaseCodegenTestCase {
       ),
       shape(
         'input' => darray[
-          'single-item-array-ref' => varray[
+          'single-item-array-ref' => vec[
             darray['string' => 'test', 'integer' => 5],
             darray['string' => 'test2', 'integer' => 10],
           ],


### PR DESCRIPTION
## Description
Remove coercion that was included to support either PHP or hack arrays. We expect only `vec`s now.