### PR TITLE
Use `COPY --from` to install composer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM hhvm/hhvm:4.128.2
 RUN apt update -y
 RUN DEBIAN_FRONTEND=noninteractive apt install -y php-cli zip unzip openssh-client
 
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 ENV HHVM_VERSION=4.128.2
 
-ADD . /app
 WORKDIR /app
+COPY . /app


### PR DESCRIPTION
Basically use `COPY --from` to install the latest `composer`.

Also replace `ADD` by `COPY` which is preferred for non-urls.