### PR TITLE
Revert changes that removed ArrayConstraint coercion

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,7 +8,7 @@ jobs:
       # Run tests on all OS's and HHVM versions, even if one fails
       fail-fast: false
       matrix:
-        os: [ubuntu]
+        os: [ ubuntu ]
         hhvm:
           - "4.128"
     runs-on: ${{matrix.os}}-latest

--- a/src/Constraints/ArrayConstraint.php
+++ b/src/Constraints/ArrayConstraint.php
@@ -3,7 +3,8 @@
 namespace Slack\Hack\JsonSchema\Constraints;
 
 use namespace HH\Lib\Str;
-use namespace Facebook\{TypeAssert, TypeSpec};
+use type Facebook\TypeAssert\{TypeCoercionException};
+use namespace Facebook\TypeSpec;
 use namespace Slack\Hack\JsonSchema;
 
 class ArrayConstraint {
@@ -25,8 +26,9 @@ class ArrayConstraint {
 
     $spec = TypeSpec\vec(TypeSpec\mixed());
     try {
-      return $spec->assertType($input);
-    } catch (TypeAssert\IncorrectTypeException $e) {
+      # To allow for either PHP or hack arrays, we coerce to a vec here.
+      return $spec->coerceType($input);
+    } catch (TypeCoercionException $e) {
       $error = shape(
         'code' => JsonSchema\FieldErrorCode::INVALID_TYPE,
         'message' => 'must provide an array',

--- a/tests/ArraySchemaValidatorTest.php
+++ b/tests/ArraySchemaValidatorTest.php
@@ -18,7 +18,7 @@ final class ArraySchemaValidatorTest extends BaseCodegenTestCase {
   }
 
   public function testArrayOfStringsInvalidRoot(): void {
-    $validator = new ArraySchemaValidator(vec['test', 'list', 'of', 'strings']);
+    $validator = new ArraySchemaValidator(varray['test', 'list', 'of', 'strings']);
     $validator->validate();
 
     expect($validator->isValid())->toBeFalse();
@@ -36,7 +36,7 @@ final class ArraySchemaValidatorTest extends BaseCodegenTestCase {
   }
 
   public function testArrayOfStringsLegacyArrays(): void {
-    $validator = new ArraySchemaValidator(darray['array_of_strings' => vec['test', 'list', 'of', 'strings']]);
+    $validator = new ArraySchemaValidator(darray['array_of_strings' => varray['test', 'list', 'of', 'strings']]);
     $validator->validate();
 
     expect($validator->isValid())->toBeTrue();
@@ -44,18 +44,20 @@ final class ArraySchemaValidatorTest extends BaseCodegenTestCase {
     expect(C\count($validated['array_of_strings'] ?? vec[]))->toBeSame(4);
   }
 
-  public function testDictOfStringsInvalid(): void {
+  public function testArrayOfStringsLegacyAndHackArrays(): void {
     $validator = new ArraySchemaValidator(dict[
-      'array_of_strings' => dict['test' => 'test'],
+      'array_of_strings' => varray['test', 'list', 'of', 'strings'],
     ]);
     $validator->validate();
 
-    expect($validator->isValid())->toBeFalse();
+    expect($validator->isValid())->toBeTrue();
+    $validated = $validator->getValidatedInput();
+    expect(C\count($validated['array_of_strings'] ?? vec[]))->toBeSame(4);
   }
 
   public function testUntypedArrayValid(): void {
     $validator = new ArraySchemaValidator(dict[
-      'untyped_array' => vec['test', 'values'],
+      'untyped_array' => varray['test', 'values'],
     ]);
     $validator->validate();
 

--- a/tests/DiscardAddititionalPropertiesValidatorTest.php
+++ b/tests/DiscardAddititionalPropertiesValidatorTest.php
@@ -61,7 +61,7 @@ final class DiscardAddititionalPropertiesValidatorTest extends BaseCodegenTestCa
     $input = dict[
       'additional_properties_ref' => dict[
         'something' => dict[
-          'something-else' => vec['array', 'of', 'strings'],
+          'something-else' => varray['array', 'of', 'strings'],
         ],
       ],
     ];
@@ -73,7 +73,7 @@ final class DiscardAddititionalPropertiesValidatorTest extends BaseCodegenTestCa
     $input = dict[
       'additional_properties_ref' => dict[
         'something' => dict[
-          'something-else' => vec[34, 'of', 'strings'],
+          'something-else' => varray[34, 'of', 'strings'],
         ],
       ],
     ];

--- a/tests/ObjectSchemaValidatorTest.php
+++ b/tests/ObjectSchemaValidatorTest.php
@@ -486,7 +486,7 @@ final class ObjectSchemaValidatorTest extends BaseCodegenTestCase {
   public function testAdditionalProperitesArray(): void {
     $input = dict[
       'additional_properties_array' => dict[
-        'something' => vec['array', 'of', 'strings'],
+        'something' => varray['array', 'of', 'strings'],
       ],
     ];
 
@@ -496,7 +496,7 @@ final class ObjectSchemaValidatorTest extends BaseCodegenTestCase {
 
     $input = dict[
       'additional_properties_array' => dict[
-        'something' => vec[34, 'of', 'strings'],
+        'something' => varray[34, 'of', 'strings'],
       ],
     ];
 
@@ -509,7 +509,7 @@ final class ObjectSchemaValidatorTest extends BaseCodegenTestCase {
     $input = dict[
       'additional_properties_ref' => dict[
         'something' => dict[
-          'something-else' => vec['array', 'of', 'strings'],
+          'something-else' => varray['array', 'of', 'strings'],
         ],
       ],
     ];
@@ -521,7 +521,7 @@ final class ObjectSchemaValidatorTest extends BaseCodegenTestCase {
     $input = dict[
       'additional_properties_ref' => dict[
         'something' => dict[
-          'something-else' => vec[34, 'of', 'strings'],
+          'something-else' => varray[34, 'of', 'strings'],
         ],
       ],
     ];

--- a/tests/PersonSchemaValidatorTest.php
+++ b/tests/PersonSchemaValidatorTest.php
@@ -172,7 +172,7 @@ final class PersonSchemaValidatorTest extends BaseCodegenTestCase {
     $devices = $validated['devices'] ?? null as nonnull;
 
     $device = $devices[0];
-    invariant(\HH\is_php_array($device), 'device should be array');
+    invariant($device is AnyArray<_, _>, 'device should be array');
 
     $extra = $device['extra'] ?? null;
     expect($extra)->toBeSame(true, 'additional properties should  be included in output');
@@ -200,7 +200,7 @@ final class PersonSchemaValidatorTest extends BaseCodegenTestCase {
     $devices = $validated['devices'] ?? null as nonnull;
 
     $device = $devices[0];
-    invariant(\HH\is_php_array($device), 'device should be array');
+    invariant($device is AnyArray<_, _>, 'device should be array');
 
     $extra = $device['extra'] ?? null;
     expect($extra)->toBeSame(null, "additional properties aren't set if other properties are defined");

--- a/tests/PersonSchemaValidatorTest.php
+++ b/tests/PersonSchemaValidatorTest.php
@@ -172,7 +172,7 @@ final class PersonSchemaValidatorTest extends BaseCodegenTestCase {
     $devices = $validated['devices'] ?? null as nonnull;
 
     $device = $devices[0];
-    invariant($device is AnyArray<_, _>, 'device should be array');
+    invariant(\HH\is_php_array($device), 'device should be array');
 
     $extra = $device['extra'] ?? null;
     expect($extra)->toBeSame(true, 'additional properties should  be included in output');
@@ -200,7 +200,7 @@ final class PersonSchemaValidatorTest extends BaseCodegenTestCase {
     $devices = $validated['devices'] ?? null as nonnull;
 
     $device = $devices[0];
-    invariant($device is AnyArray<_, _>, 'device should be array');
+    invariant(\HH\is_php_array($device), 'device should be array');
 
     $extra = $device['extra'] ?? null;
     expect($extra)->toBeSame(null, "additional properties aren't set if other properties are defined");

--- a/tests/RefSchemaValidatorTest.php
+++ b/tests/RefSchemaValidatorTest.php
@@ -64,7 +64,7 @@ final class RefSchemaValidatorTest extends BaseCodegenTestCase {
       ),
       shape(
         'input' => darray[
-          'single-item-array-ref' => vec[
+          'single-item-array-ref' => varray[
             darray['string' => 'test', 'integer' => 5],
             darray['string' => 'test2', 'integer' => 10],
           ],


### PR DESCRIPTION
Reverts this PR: https://github.com/slackhq/hack-json-schema/pull/55

This caused some unanticipated failures, so we'll want to look into this work again!