### PR TITLE
Support hackEnum and unique constraints together

### DIFF
--- a/src/Codegen/Constraints/ArrayBuilder.php
+++ b/src/Codegen/Constraints/ArrayBuilder.php
@@ -2,6 +2,7 @@
 
 namespace Slack\Hack\JsonSchema\Codegen;
 
+use namespace HH\Lib\C;
 use type Facebook\HackCodegen\{CodegenMethod, HackBuilder, HackBuilderValues};
 
 type TArraySchema = shape(
@@ -264,12 +265,12 @@ class ArrayBuilder extends BaseBuilder<TArraySchema> {
    * Determine the type of hack array we will generate.
    */
   private function determineHackArrayType(): void {
-    if ($this->schema['uniqueItems'] ?? false) {
-      $item_type = $this->singleItemSchemaBuilder?->getType();
-      if ($item_type === 'string' || $item_type === 'int') {
+    $items = $this->typed_schema['items'] ?? null;
+    if (($this->schema['uniqueItems'] ?? false) && $this->isSchema($items)) {
+      $schema = type_assert_type($items, TArraySchemaItemsSingleSchema::class);
+      if (C\contains(keyset[TSchemaType::INTEGER_T, TSchemaType::STRING_T], $schema['type'] ?? null)) {
         $this->hackArrayType = HackArrayType::KEYSET;
       }
     }
   }
-
 }

--- a/tests/ArraySchemaValidatorTest.php
+++ b/tests/ArraySchemaValidatorTest.php
@@ -230,4 +230,16 @@ final class ArraySchemaValidatorTest extends BaseCodegenTestCase {
     expect($validated)->toEqual(shape('hack_enum_items' => vec[TestStringEnum::ABC, TestStringEnum::DEF]));
   }
 
+  public function testUniqueHackEnum(): void {
+    $input = vec['foo', 'bar', 'foo'];
+
+    $validator = new ArraySchemaValidator(dict['unique_hack_enum_items' => $input]);
+    $validator->validate();
+
+    expect($validator->isValid())->toBeTrue();
+    $validated = $validator->getValidatedInput();
+
+    expect($validated)->toEqual(shape('unique_hack_enum_items' => keyset[TestStringEnum::ABC, TestStringEnum::DEF]));
+  }
+
 }

--- a/tests/examples/array-schema.json
+++ b/tests/examples/array-schema.json
@@ -54,7 +54,15 @@
     },
     "hack_enum_items": {
       "type": "array",
+      "items": {
+        "type": "string",
+        "hackEnum": "Slack\\Hack\\JsonSchema\\Tests\\TestStringEnum"
+      }
+    },
+    "unique_hack_enum_items": {
+      "type": "array",
       "uniqueItems": true,
+      "coerce": true,
       "items": {
         "type": "string",
         "hackEnum": "Slack\\Hack\\JsonSchema\\Tests\\TestStringEnum"

--- a/tests/examples/codegen/ArraySchemaValidator.php
+++ b/tests/examples/codegen/ArraySchemaValidator.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<87191fcc75856e69e35c2652ba5f9836>>
+ * @generated SignedSource<<7f20c3eead69c411ea999a821ff7167a>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;
@@ -25,6 +25,7 @@ type TArraySchemaValidator = shape(
   ?'unique_numbers_coerce' => keyset<int>,
   ?'unsupported_unique_items' => vec<TArraySchemaValidatorPropertiesUnsupportedUniqueItemsItems>,
   ?'hack_enum_items' => vec<\Slack\Hack\JsonSchema\Tests\TestStringEnum>,
+  ?'unique_hack_enum_items' => keyset<\Slack\Hack\JsonSchema\Tests\TestStringEnum>,
   ...
 );
 
@@ -392,6 +393,63 @@ final class ArraySchemaValidatorPropertiesHackEnumItems {
   }
 }
 
+final class ArraySchemaValidatorPropertiesUniqueHackEnumItemsItems {
+
+  private static bool $coerce = false;
+
+  public static function check(
+    mixed $input,
+    string $pointer,
+  ): \Slack\Hack\JsonSchema\Tests\TestStringEnum {
+    $typed = Constraints\StringConstraint::check($input, $pointer, self::$coerce);
+
+    $typed = Constraints\HackEnumConstraint::check(
+      $typed,
+      \Slack\Hack\JsonSchema\Tests\TestStringEnum::class,
+      $pointer,
+    );
+    return $typed;
+  }
+}
+
+final class ArraySchemaValidatorPropertiesUniqueHackEnumItems {
+
+  private static bool $coerce = true;
+
+  public static function check(
+    mixed $input,
+    string $pointer,
+  ): keyset<\Slack\Hack\JsonSchema\Tests\TestStringEnum> {
+    $typed = Constraints\ArrayConstraint::check($input, $pointer, self::$coerce);
+
+    $output = vec[];
+    $errors = vec[];
+
+    foreach ($typed as $index => $value) {
+      try {
+        $output[] = ArraySchemaValidatorPropertiesUniqueHackEnumItemsItems::check(
+          $value,
+          JsonSchema\get_pointer($pointer, (string) $index),
+        );
+      } catch (JsonSchema\InvalidFieldException $e) {
+        $errors = \HH\Lib\Vec\concat($errors, $e->errors);
+      }
+    }
+
+    if (\HH\Lib\C\count($errors)) {
+      throw new JsonSchema\InvalidFieldException($pointer, $errors);
+    }
+
+    $output = Constraints\ArrayUniqueItemsConstraint::check(
+      $output,
+      $pointer,
+      self::$coerce,
+    );
+
+    return $output;
+  }
+}
+
 final class ArraySchemaValidator
   extends JsonSchema\BaseValidator<TArraySchemaValidator> {
 
@@ -494,6 +552,17 @@ final class ArraySchemaValidator
         $output['hack_enum_items'] = ArraySchemaValidatorPropertiesHackEnumItems::check(
           $typed['hack_enum_items'],
           JsonSchema\get_pointer($pointer, 'hack_enum_items'),
+        );
+      } catch (JsonSchema\InvalidFieldException $e) {
+        $errors = \HH\Lib\Vec\concat($errors, $e->errors);
+      }
+    }
+
+    if (\HH\Lib\C\contains_key($typed, 'unique_hack_enum_items')) {
+      try {
+        $output['unique_hack_enum_items'] = ArraySchemaValidatorPropertiesUniqueHackEnumItems::check(
+          $typed['unique_hack_enum_items'],
+          JsonSchema\get_pointer($pointer, 'unique_hack_enum_items'),
         );
       } catch (JsonSchema\InvalidFieldException $e) {
         $errors = \HH\Lib\Vec\concat($errors, $e->errors);


### PR DESCRIPTION
Supports using `hackEnum` in a list with `"uniqueItems": true`.

This would be a bit cleaner if we had an `IntegerBuilder` which was separate from `NumberBuilder`, but that seemed like a bigger change.