### PR TITLE
Handle hackEnum item refs correctly

### DIFF
--- a/src/Codegen/Codegen.php
+++ b/src/Codegen/Codegen.php
@@ -108,7 +108,24 @@ final class Codegen {
     ),
   );
 
-  private function __construct(private dict<arraykey, mixed> $schema, private self::TCodegenConfig $config) {}
+  private ValidatorBuilder $builder;
+
+  private function __construct(private dict<arraykey, mixed> $schema, private self::TCodegenConfig $config) {
+    $config = $this->config['validator'];
+
+    $builder = new ValidatorBuilder(
+      $this->config,
+      $this->getHackCodegenConfig(),
+      $this->getJsonSchemaCodegenConfig(),
+      $this->schema,
+    );
+
+    $this->builder = $builder
+      ->setCreateAbstractClass(false)
+      ->setGeneratedFrom($this->getGeneratedFrom())
+      ->setDiscardChanges($this->config['discardChanges'] ?? false)
+      ->setSanitizeString($config['sanitize_string'] ?? null);
+  }
 
   /**
   * Generate validators for multiple schema paths. This requires using unique
@@ -212,25 +229,10 @@ final class Codegen {
   }
 
   public function build(): CodegenFile {
-    return $this->buildValidator();
+    return $this->builder->build();
   }
 
-  private function buildValidator(): CodegenFile {
-    $config = $this->config['validator'];
-
-    $builder = new ValidatorBuilder(
-      $this->config,
-      $this->getHackCodegenConfig(),
-      $this->getJsonSchemaCodegenConfig(),
-      $this->schema,
-    );
-
-    return $builder
-      ->setCreateAbstractClass(false)
-      ->setGeneratedFrom($this->getGeneratedFrom())
-      ->setDiscardChanges($this->config['discardChanges'] ?? false)
-      ->setSanitizeString($config['sanitize_string'] ?? null)
-      ->renderToFile($config['file'], $config['namespace'] ?? null, $config['class']);
+  public function getBuilder(): ValidatorBuilder {
+    return $this->builder;
   }
-
 }

--- a/src/Codegen/Constraints/ArrayBuilder.php
+++ b/src/Codegen/Constraints/ArrayBuilder.php
@@ -2,7 +2,6 @@
 
 namespace Slack\Hack\JsonSchema\Codegen;
 
-use namespace HH\Lib\C;
 use type Facebook\HackCodegen\{CodegenMethod, HackBuilder, HackBuilderValues};
 
 type TArraySchema = shape(
@@ -266,11 +265,12 @@ class ArrayBuilder extends BaseBuilder<TArraySchema> {
    */
   private function determineHackArrayType(): void {
     $items = $this->typed_schema['items'] ?? null;
-    if (($this->schema['uniqueItems'] ?? false) && $this->isSchema($items)) {
-      $schema = type_assert_type($items, TArraySchemaItemsSingleSchema::class);
-      if (C\contains(keyset[TSchemaType::INTEGER_T, TSchemaType::STRING_T], $schema['type'] ?? null)) {
-        $this->hackArrayType = HackArrayType::KEYSET;
-      }
+    if (
+      Shapes::idx($this->typed_schema, 'uniqueItems') &&
+      $this->isSchema($items) &&
+      $this->singleItemSchemaBuilder?->isArrayKeyType()
+    ) {
+      $this->hackArrayType = HackArrayType::KEYSET;
     }
   }
 }

--- a/src/Codegen/Constraints/BaseBuilder.php
+++ b/src/Codegen/Constraints/BaseBuilder.php
@@ -29,6 +29,16 @@ abstract class BaseBuilder<T> implements IBuilder {
   */
   abstract public function getType(): string;
 
+  public function isArrayKeyType(): bool {
+    $type = $this->getType();
+    if ($type === 'string' || $type === 'int') {
+      return true;
+    }
+
+    $schema = type_assert_type($this->typed_schema, TSchema::class);
+    return Shapes::keyExists($schema, 'hackEnum');
+  }
+
   /**
   *
   * Main method for building the class for the schema and appending it to the

--- a/src/Codegen/Constraints/IBuilder.php
+++ b/src/Codegen/Constraints/IBuilder.php
@@ -6,5 +6,6 @@ interface IBuilder {
   public function build(): this;
   public function getClassName(): string;
   public function getType(): string;
+  public function isArrayKeyType(): bool;
   public function setSuffix(string $suffix): void;
 }

--- a/src/Codegen/Constraints/RootBuilder.php
+++ b/src/Codegen/Constraints/RootBuilder.php
@@ -31,8 +31,20 @@ final class RootBuilder implements IBuilder {
     return $this->root->getClassName();
   }
 
+  public function getClass(): CodegenClass {
+    return $this->class;
+  }
+
+  public function getFile(): CodegenFile {
+    return $this->file;
+  }
+
   public function getType(): string {
     return $this->root->getType();
+  }
+
+  public function isArrayKeyType(): bool {
+    return $this->root->isArrayKeyType();
   }
 
   public function setSuffix(string $_suffix): void {

--- a/src/Codegen/Constraints/SchemaBuilder.php
+++ b/src/Codegen/Constraints/SchemaBuilder.php
@@ -152,6 +152,10 @@ class SchemaBuilder implements IBuilder {
     return $this->builder->getType();
   }
 
+  public function isArrayKeyType(): bool {
+    return $this->builder->isArrayKeyType();
+  }
+
   public function getClassName(): string {
     return $this->builder->getClassName();
   }

--- a/src/Codegen/Constraints/UniqueRefBuilder.php
+++ b/src/Codegen/Constraints/UniqueRefBuilder.php
@@ -2,7 +2,7 @@
 
 namespace Slack\Hack\JsonSchema\Codegen;
 
-use namespace HH\Lib\{Str, Vec};
+use namespace HH\Lib\Str;
 
 use type Facebook\HackCodegen\CodegenMethod;
 

--- a/src/Codegen/Constraints/UniqueRefBuilder.php
+++ b/src/Codegen/Constraints/UniqueRefBuilder.php
@@ -13,7 +13,7 @@ class UniqueRefBuilder implements IBuilder {
 
   private string $classname;
   private string $filename;
-  private ?string $type;
+  private ?RootBuilder $builder;
 
   public function __construct(protected Context $ctx, protected string $ref, protected TSchema $schema) {
     $this->classname = '';
@@ -62,33 +62,16 @@ class UniqueRefBuilder implements IBuilder {
     $codegen_config['validator']['refs'] = $refs_config;
     $codegen_config['validator']['context'] = $context_config;
 
-    $codegen = Codegen::forSchema(Shapes::toDict($this->schema), $codegen_config, $root_directory);
-
-    $codegen_file = null;
     if (RefCache::isRefCached($this->filename)) {
-      $codegen_file = RefCache::getCachedFile($this->filename);
+      $codegen = RefCache::getCachedCodegen($this->filename);
     } else {
-      $codegen_file = $codegen->build();
+      $codegen = Codegen::forSchema(Shapes::toDict($this->schema), $codegen_config, $root_directory);
+      $codegen->build();
+      RefCache::cacheRef($this->filename, $codegen);
     }
 
-    RefCache::cacheRef($this->filename, $codegen_file);
-
-    $main_class = Vec\filter($codegen_file->getClasses(), $class ==> $class->getName() === $this->classname)[0];
-
-    $methods = get_private_property(\get_class($main_class), 'methods', $main_class)
-      |> type_assert_shape($$, '\Slack\Hack\JsonSchema\Codegen\TCodegenMethods');
-
-    $check_method = Vec\filter(
-      $methods,
-      $method ==> {
-        $name = get_private_property(\get_class($method), 'name', $method);
-        return $name === 'check';
-      },
-    )[0];
-
-    $return_type = get_private_property(\get_class($check_method), 'returnType', $check_method);
-    $this->type = $return_type as string;
-
+    $validator_builder = $codegen->getBuilder();
+    $this->builder = $validator_builder->getBuilder();
     return $this;
   }
 
@@ -97,8 +80,13 @@ class UniqueRefBuilder implements IBuilder {
   }
 
   public function getType(): string {
-    invariant($this->type is nonnull, 'must call `build` method before accessing type');
-    return $this->type;
+    invariant($this->builder is nonnull, 'must call `build` method before accessing type');
+    return $this->builder->getType();
+  }
+
+  public function isArrayKeyType(): bool {
+    invariant($this->builder is nonnull, 'must call `build` method before accessing type');
+    return $this->builder->isArrayKeyType();
   }
 
   public function setSuffix(string $_suffix): void {

--- a/src/Codegen/RefCache.php
+++ b/src/Codegen/RefCache.php
@@ -3,11 +3,10 @@
 namespace Slack\Hack\JsonSchema\Codegen;
 
 use namespace HH\Lib\C;
-use type Facebook\HackCodegen\CodegenFile;
 
 final class RefCache {
 
-  static private dict<string, CodegenFile> $generatedRefs = dict[];
+  static private dict<string, Codegen> $generatedRefs = dict[];
 
   //
   // Run this resetCache before using any other method
@@ -22,8 +21,8 @@ final class RefCache {
   // the full pathname of the file.
   //
 
-  static public function cacheRef(string $refName, CodegenFile $file): void {
-    RefCache::$generatedRefs[$refName] = $file;
+  static public function cacheRef(string $refName, Codegen $codegen): void {
+    RefCache::$generatedRefs[$refName] = $codegen;
   }
 
   //
@@ -36,11 +35,11 @@ final class RefCache {
 
   //
   // Do not use this function unless you have already verified that a
-  // CodegenFile exists for $refName. This function will not gracefully
+  // Codegen exists for $refName. This function will not gracefully
   // handle the case when $refName is not found in the cache.
   //
 
-  static public function getCachedFile(string $refName): CodegenFile {
+  static public function getCachedCodegen(string $refName): Codegen {
     return RefCache::$generatedRefs[$refName];
   }
 }

--- a/tests/ArraySchemaValidatorTest.php
+++ b/tests/ArraySchemaValidatorTest.php
@@ -12,7 +12,18 @@ final class ArraySchemaValidatorTest extends BaseCodegenTestCase {
 
   <<__Override>>
   public static async function beforeFirstTestAsync(): Awaitable<void> {
-    $ret = self::getBuilder('array-schema.json', 'ArraySchemaValidator');
+    $ret = self::getBuilder(
+      'array-schema.json',
+      'ArraySchemaValidator',
+      shape(
+        'refs' => shape(
+          'unique' => shape(
+            'source_root' => __DIR__,
+            'output_root' => __DIR__.'/examples/codegen',
+          ),
+        ),
+      ),
+    );
     $ret['codegen']->build();
     require_once($ret['path']);
   }
@@ -162,6 +173,18 @@ final class ArraySchemaValidatorTest extends BaseCodegenTestCase {
     expect($constraint['got'] ?? null)->toEqual($input);
   }
 
+  public function testUniqueItemsWithValidStringRef(): void {
+    $input = vec['a', 'b', 'c'];
+
+    $validator = new ArraySchemaValidator(dict['unique_strings_ref' => $input]);
+    $validator->validate();
+
+    expect($validator->isValid())->toBeTrue();
+    $validated = $validator->getValidatedInput();
+
+    expect($validated)->toBeSame(shape('unique_strings_ref' => keyset($input)));
+  }
+
   public function testUniqueItemsWithValidNumbers(): void {
     $input = vec[1, 2, 3];
 
@@ -240,6 +263,20 @@ final class ArraySchemaValidatorTest extends BaseCodegenTestCase {
     $validated = $validator->getValidatedInput();
 
     expect($validated)->toEqual(shape('unique_hack_enum_items' => keyset[TestStringEnum::ABC, TestStringEnum::DEF]));
+  }
+
+  public function testUniqueHackEnumItemsRef(): void {
+    $input = vec['foo', 'bar', 'foo'];
+
+    $validator = new ArraySchemaValidator(dict['unique_hack_enum_items_ref' => $input]);
+    $validator->validate();
+
+    expect($validator->isValid())->toBeTrue();
+    $validated = $validator->getValidatedInput();
+
+    expect($validated)->toEqual(
+      shape('unique_hack_enum_items_ref' => keyset[TestStringEnum::ABC, TestStringEnum::DEF]),
+    );
   }
 
 }

--- a/tests/examples/array-schema.json
+++ b/tests/examples/array-schema.json
@@ -25,6 +25,13 @@
         "type": "string"
       }
     },
+    "unique_strings_ref": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "string-schema.json#/definitions/simple"
+      }
+    },
     "unique_numbers": {
       "type": "array",
       "uniqueItems": true,
@@ -66,6 +73,14 @@
       "items": {
         "type": "string",
         "hackEnum": "Slack\\Hack\\JsonSchema\\Tests\\TestStringEnum"
+      }
+    },
+    "unique_hack_enum_items_ref": {
+      "type": "array",
+      "uniqueItems": true,
+      "coerce": true,
+      "items": {
+        "$ref": "string-schema.json#/definitions/hack_enum"
       }
     }
   }

--- a/tests/examples/codegen/ArraySchemaValidator.php
+++ b/tests/examples/codegen/ArraySchemaValidator.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<7f20c3eead69c411ea999a821ff7167a>>
+ * @generated SignedSource<<f96098668f71332c561e089e8dca24c7>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;
@@ -21,11 +21,13 @@ type TArraySchemaValidator = shape(
   ?'untyped_array' => vec<mixed>,
   ?'coerce_array' => vec<num>,
   ?'unique_strings' => keyset<string>,
+  ?'unique_strings_ref' => keyset<string>,
   ?'unique_numbers' => keyset<int>,
   ?'unique_numbers_coerce' => keyset<int>,
   ?'unsupported_unique_items' => vec<TArraySchemaValidatorPropertiesUnsupportedUniqueItemsItems>,
   ?'hack_enum_items' => vec<\Slack\Hack\JsonSchema\Tests\TestStringEnum>,
   ?'unique_hack_enum_items' => keyset<\Slack\Hack\JsonSchema\Tests\TestStringEnum>,
+  ?'unique_hack_enum_items_ref' => keyset<\Slack\Hack\JsonSchema\Tests\TestStringEnum>,
   ...
 );
 
@@ -144,6 +146,41 @@ final class ArraySchemaValidatorPropertiesUniqueStrings {
     foreach ($typed as $index => $value) {
       try {
         $output[] = ArraySchemaValidatorPropertiesUniqueStringsItems::check(
+          $value,
+          JsonSchema\get_pointer($pointer, (string) $index),
+        );
+      } catch (JsonSchema\InvalidFieldException $e) {
+        $errors = \HH\Lib\Vec\concat($errors, $e->errors);
+      }
+    }
+
+    if (\HH\Lib\C\count($errors)) {
+      throw new JsonSchema\InvalidFieldException($pointer, $errors);
+    }
+
+    $output = Constraints\ArrayUniqueItemsConstraint::check(
+      $output,
+      $pointer,
+      self::$coerce,
+    );
+
+    return $output;
+  }
+}
+
+final class ArraySchemaValidatorPropertiesUniqueStringsRef {
+
+  private static bool $coerce = false;
+
+  public static function check(mixed $input, string $pointer): keyset<string> {
+    $typed = Constraints\ArrayConstraint::check($input, $pointer, self::$coerce);
+
+    $output = vec[];
+    $errors = vec[];
+
+    foreach ($typed as $index => $value) {
+      try {
+        $output[] = ExamplesStringSchemaDefinitionsSimple::check(
           $value,
           JsonSchema\get_pointer($pointer, (string) $index),
         );
@@ -450,6 +487,44 @@ final class ArraySchemaValidatorPropertiesUniqueHackEnumItems {
   }
 }
 
+final class ArraySchemaValidatorPropertiesUniqueHackEnumItemsRef {
+
+  private static bool $coerce = true;
+
+  public static function check(
+    mixed $input,
+    string $pointer,
+  ): keyset<\Slack\Hack\JsonSchema\Tests\TestStringEnum> {
+    $typed = Constraints\ArrayConstraint::check($input, $pointer, self::$coerce);
+
+    $output = vec[];
+    $errors = vec[];
+
+    foreach ($typed as $index => $value) {
+      try {
+        $output[] = ExamplesStringSchemaDefinitionsHackEnum::check(
+          $value,
+          JsonSchema\get_pointer($pointer, (string) $index),
+        );
+      } catch (JsonSchema\InvalidFieldException $e) {
+        $errors = \HH\Lib\Vec\concat($errors, $e->errors);
+      }
+    }
+
+    if (\HH\Lib\C\count($errors)) {
+      throw new JsonSchema\InvalidFieldException($pointer, $errors);
+    }
+
+    $output = Constraints\ArrayUniqueItemsConstraint::check(
+      $output,
+      $pointer,
+      self::$coerce,
+    );
+
+    return $output;
+  }
+}
+
 final class ArraySchemaValidator
   extends JsonSchema\BaseValidator<TArraySchemaValidator> {
 
@@ -514,6 +589,17 @@ final class ArraySchemaValidator
       }
     }
 
+    if (\HH\Lib\C\contains_key($typed, 'unique_strings_ref')) {
+      try {
+        $output['unique_strings_ref'] = ArraySchemaValidatorPropertiesUniqueStringsRef::check(
+          $typed['unique_strings_ref'],
+          JsonSchema\get_pointer($pointer, 'unique_strings_ref'),
+        );
+      } catch (JsonSchema\InvalidFieldException $e) {
+        $errors = \HH\Lib\Vec\concat($errors, $e->errors);
+      }
+    }
+
     if (\HH\Lib\C\contains_key($typed, 'unique_numbers')) {
       try {
         $output['unique_numbers'] = ArraySchemaValidatorPropertiesUniqueNumbers::check(
@@ -563,6 +649,17 @@ final class ArraySchemaValidator
         $output['unique_hack_enum_items'] = ArraySchemaValidatorPropertiesUniqueHackEnumItems::check(
           $typed['unique_hack_enum_items'],
           JsonSchema\get_pointer($pointer, 'unique_hack_enum_items'),
+        );
+      } catch (JsonSchema\InvalidFieldException $e) {
+        $errors = \HH\Lib\Vec\concat($errors, $e->errors);
+      }
+    }
+
+    if (\HH\Lib\C\contains_key($typed, 'unique_hack_enum_items_ref')) {
+      try {
+        $output['unique_hack_enum_items_ref'] = ArraySchemaValidatorPropertiesUniqueHackEnumItemsRef::check(
+          $typed['unique_hack_enum_items_ref'],
+          JsonSchema\get_pointer($pointer, 'unique_hack_enum_items_ref'),
         );
       } catch (JsonSchema\InvalidFieldException $e) {
         $errors = \HH\Lib\Vec\concat($errors, $e->errors);

--- a/tests/examples/codegen/ExamplesStringSchemaDefinitionsHackEnum.php
+++ b/tests/examples/codegen/ExamplesStringSchemaDefinitionsHackEnum.php
@@ -1,0 +1,37 @@
+<?hh // strict
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * To re-generate this file run `make test`
+ *
+ *
+ * @generated SignedSource<<f5a043eba14cf8234dc6d98904607c0d>>
+ */
+namespace Slack\Hack\JsonSchema\Tests\Generated;
+use namespace Slack\Hack\JsonSchema;
+use namespace Slack\Hack\JsonSchema\Constraints;
+
+final class ExamplesStringSchemaDefinitionsHackEnum
+  extends JsonSchema\BaseValidator<\Slack\Hack\JsonSchema\Tests\TestStringEnum> {
+
+  private static bool $coerce = false;
+
+  public static function check(
+    mixed $input,
+    string $pointer,
+  ): \Slack\Hack\JsonSchema\Tests\TestStringEnum {
+    $typed = Constraints\StringConstraint::check($input, $pointer, self::$coerce);
+
+    $typed = Constraints\HackEnumConstraint::check(
+      $typed,
+      \Slack\Hack\JsonSchema\Tests\TestStringEnum::class,
+      $pointer,
+    );
+    return $typed;
+  }
+
+  <<__Override>>
+  protected function process(): \Slack\Hack\JsonSchema\Tests\TestStringEnum {
+    return self::check($this->input, $this->pointer);
+  }
+}

--- a/tests/examples/codegen/ExamplesStringSchemaDefinitionsSimple.php
+++ b/tests/examples/codegen/ExamplesStringSchemaDefinitionsSimple.php
@@ -1,0 +1,29 @@
+<?hh // strict
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * To re-generate this file run `make test`
+ *
+ *
+ * @generated SignedSource<<5da95a9832385ebd685100a1a6bf44f5>>
+ */
+namespace Slack\Hack\JsonSchema\Tests\Generated;
+use namespace Slack\Hack\JsonSchema;
+use namespace Slack\Hack\JsonSchema\Constraints;
+
+final class ExamplesStringSchemaDefinitionsSimple
+  extends JsonSchema\BaseValidator<string> {
+
+  private static bool $coerce = false;
+
+  public static function check(mixed $input, string $pointer): string {
+    $typed = Constraints\StringConstraint::check($input, $pointer, self::$coerce);
+
+    return $typed;
+  }
+
+  <<__Override>>
+  protected function process(): string {
+    return self::check($this->input, $this->pointer);
+  }
+}

--- a/tests/examples/codegen/RefSchemaValidator.php
+++ b/tests/examples/codegen/RefSchemaValidator.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<98eaf6ad9c7dad3c90928ea79b70f4e7>>
+ * @generated SignedSource<<8b989ac14d2b7d0004cd6b8bc0b8e7b5>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;
@@ -24,6 +24,7 @@ type TRefSchemaValidatorPropertiesDuplicateRefs = shape(
 
 type TRefSchemaValidator = shape(
   ?'local-reference' => TExamplesRefSchemaDefinitionsLocalObjectReference,
+  ?'string-reference' => string,
   ?'remote-reference' => string,
   ?'remote-reference-self' => string,
   ?'remote-same-dir-reference' => string,
@@ -213,6 +214,17 @@ final class RefSchemaValidator
         $output['local-reference'] = ExamplesRefSchemaDefinitionsLocalObjectReference::check(
           $typed['local-reference'],
           JsonSchema\get_pointer($pointer, 'local-reference'),
+        );
+      } catch (JsonSchema\InvalidFieldException $e) {
+        $errors = \HH\Lib\Vec\concat($errors, $e->errors);
+      }
+    }
+
+    if (\HH\Lib\C\contains_key($typed, 'string-reference')) {
+      try {
+        $output['string-reference'] = ExamplesStringSchemaDefinitionsSimple::check(
+          $typed['string-reference'],
+          JsonSchema\get_pointer($pointer, 'string-reference'),
         );
       } catch (JsonSchema\InvalidFieldException $e) {
         $errors = \HH\Lib\Vec\concat($errors, $e->errors);

--- a/tests/examples/ref-schema.json
+++ b/tests/examples/ref-schema.json
@@ -4,6 +4,9 @@
     "local-reference": {
       "$ref": "#/definitions/local-object-reference"
     },
+    "string-reference": {
+      "$ref": "string-schema.json#/definitions/simple"
+    },
     "remote-reference": {
       "$ref": "#/definitions/remote-reference"
     },

--- a/tests/examples/string-schema.json
+++ b/tests/examples/string-schema.json
@@ -29,9 +29,16 @@
     }
   },
   "definitions": {
+    "simple": {
+      "type": "string"
+    },
     "coerce": {
       "type": "string",
       "coerce": true
+    },
+    "hack_enum": {
+      "type": "string",
+      "hackEnum": "Slack\\Hack\\JsonSchema\\Tests\\TestStringEnum"
     }
   }
 }


### PR DESCRIPTION
## Description

My last PR, https://github.com/slackhq/hack-json-schema/pull/63, didn't correctly handle the case where an array annotated with `uniqueItems` contains a reference to an arraykey annotated with `hackEnum`. It also broke existing arrays which contained references to arraykey and were annotated with `uniqueItems`.

To handle these cases, we need to know not only the type of the referenced schema, but whether its type is an arraykey. There was some really cludgy code in `UniqueRefsBuilder` which parses through the generated file to determine the type of the referenced schema. While I could build on that, I decided this was a good chance to refactor such that we don't need to use reflection and the maximum amount of information about each referenced schema is stored in the `RefCache`. As such:
* I updated `RefCache` to store instances of `Codegen` rather than `CodegenFile`.
* I updated `Codegen` and `ValidatorBuilder` to each store references to their builders, instead of instantiating those builders on demand in their `build()` methods. This allows us to introspect these builders to determine what sort of schema they reference. 
* Renamed `ValidatorBuilder::renderToFile` to `ValidatorBuilder::build` which is more in-line with how every other builder works.

There's still plenty more room to refactor: for example, should `Codegen` and `ValidatorBuilder` really be separate classes? What about `RootBuilder`, for that matter? That all feels like unnecessary indirection we could probably clean up.

This refactor also will make it easier to land a change we've wanted for awhile, namely the ability to use a reference as a key in a top-level schema (since now we can more easily introspect the result of calling `RootBuilder->build()` and determine that we didn't actually generate any new code).

## Testing
* I tested internally by regenerating all schemas. I noted no diff.
* I also updated one schema to us a nested `hackEnum` item type, and noticed that schemas generated correctly.