### PR TITLE
Handle string to object coercion correctly for optimized anyOf contraints

### DIFF
--- a/src/Codegen/Constraints/UntypedBuilder.php
+++ b/src/Codegen/Constraints/UntypedBuilder.php
@@ -564,10 +564,9 @@ class UntypedBuilder extends BaseBuilder<TUntypedSchema> {
 
     $hb
       ->addAssignment('$key', $any_of_types['key'], HackBuilderValues::export())
-      ->addAssignment('$coerce', $this->ctx->getCoerceDefault(), HackBuilderValues::export())
       ->addAssignment(
         '$typed',
-        'Constraints\ObjectConstraint::check($input, $pointer, $coerce)',
+        'Constraints\ObjectConstraint::check($input, $pointer, true)',
         HackBuilderValues::literal(),
       )
       ->ensureEmptyLine()
@@ -614,8 +613,10 @@ class UntypedBuilder extends BaseBuilder<TUntypedSchema> {
       ->endIfBlock()
       ->ensureEmptyLine();
 
+    // Pass $input instead of $typed here since we have coerced $typed to an object above
+    // to determine the type, but such coercion may not be allowed by the constraint.
     $hb
-      ->addMultilineCall('return $constraint', vec['$typed', '$pointer']);
+      ->addMultilineCall('return $constraint', vec['$input', '$pointer']);
   }
 
   <<__Override>>

--- a/src/Codegen/Constraints/UntypedBuilder.php
+++ b/src/Codegen/Constraints/UntypedBuilder.php
@@ -564,9 +564,10 @@ class UntypedBuilder extends BaseBuilder<TUntypedSchema> {
 
     $hb
       ->addAssignment('$key', $any_of_types['key'], HackBuilderValues::export())
+      ->addAssignment('$coerce', $this->ctx->getCoerceDefault(), HackBuilderValues::export())
       ->addAssignment(
         '$typed',
-        'Constraints\ObjectConstraint::check($input, $pointer, false)',
+        'Constraints\ObjectConstraint::check($input, $pointer, $coerce)',
         HackBuilderValues::literal(),
       )
       ->ensureEmptyLine()

--- a/tests/UntypedSchemaValidatorTest.php
+++ b/tests/UntypedSchemaValidatorTest.php
@@ -31,6 +31,7 @@ final class UntypedSchemaValidatorTest extends BaseCodegenTestCase {
           'uniline' => _untyped_schema_validator_test_uniline<>,
           'multiline' => _untyped_schema_validator_test_multiline<>,
         ),
+        'defaults' => shape('coerce' => true),
       ),
     );
     $ret['codegen']->build();
@@ -180,6 +181,25 @@ final class UntypedSchemaValidatorTest extends BaseCodegenTestCase {
     expect($error['code'])->toBeSame('invalid_type');
     expect($error['message'])->toBeSame('must provide a string');
     expect($error['pointer'] ?? null)->toBeSame('/any_of_optimized_enum/type');
+  }
+
+  public function testAnyOfOptimizedEnumCoercionInvalid(): void {
+    $input = dict[
+      'any_of_optimized_enum' => \json_encode(dict[
+        'type' => 'first',
+        'string' => 'something',
+      ]),
+    ];
+
+    $validator = new UntypedSchemaValidator($input);
+    $validator->validate();
+    expect($validator->isValid())->toBeFalse();
+    $errors = $validator->getErrors();
+    expect(C\count($errors))->toBeSame(1);
+    $error = $errors[0];
+    expect($error['code'])->toBeSame('invalid_type');
+    expect($error['message'])->toBeSame('must provide an object');
+    expect($error['pointer'] ?? null)->toBeSame('/any_of_optimized_enum');
   }
 
 }

--- a/tests/examples/codegen/CustomCodegenConfigValidator.php
+++ b/tests/examples/codegen/CustomCodegenConfigValidator.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<0ba19b292d118e34d8be5668b8588019>>
+ * @generated SignedSource<<ee119ba08bdb81ffcb9a78abe60d794d>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;
@@ -646,8 +646,7 @@ final class CustomCodegenConfigValidatorPropertiesDevicesItems {
     string $pointer,
   ): custom_codegen_config_validator_properties_devices_items_t {
     $key = 'type';
-    $coerce = false;
-    $typed = Constraints\ObjectConstraint::check($input, $pointer, $coerce);
+    $typed = Constraints\ObjectConstraint::check($input, $pointer, true);
 
     Constraints\ObjectRequiredConstraint::check($typed, keyset[$key], $pointer);
     $field_pointer = JsonSchema\get_pointer($pointer, $key);
@@ -675,7 +674,7 @@ final class CustomCodegenConfigValidatorPropertiesDevicesItems {
       throw new JsonSchema\InvalidFieldException($field_pointer, vec[$error]);
     }
 
-    return $constraint($typed, $pointer);
+    return $constraint($input, $pointer);
   }
 }
 

--- a/tests/examples/codegen/CustomCodegenConfigValidator.php
+++ b/tests/examples/codegen/CustomCodegenConfigValidator.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<e839a5cf76cbc60c3da1a15b9eb5ff3d>>
+ * @generated SignedSource<<0ba19b292d118e34d8be5668b8588019>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;
@@ -646,7 +646,8 @@ final class CustomCodegenConfigValidatorPropertiesDevicesItems {
     string $pointer,
   ): custom_codegen_config_validator_properties_devices_items_t {
     $key = 'type';
-    $typed = Constraints\ObjectConstraint::check($input, $pointer, false);
+    $coerce = false;
+    $typed = Constraints\ObjectConstraint::check($input, $pointer, $coerce);
 
     Constraints\ObjectRequiredConstraint::check($typed, keyset[$key], $pointer);
     $field_pointer = JsonSchema\get_pointer($pointer, $key);

--- a/tests/examples/codegen/PersonSchemaValidator.php
+++ b/tests/examples/codegen/PersonSchemaValidator.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<29a06b2c6c94a2e1969280850f23e6ed>>
+ * @generated SignedSource<<0e58793fe5eca9c570c3c75b5db0e416>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;
@@ -646,7 +646,8 @@ final class PersonSchemaValidatorPropertiesDevicesItems {
     string $pointer,
   ): TPersonSchemaValidatorPropertiesDevicesItems {
     $key = 'type';
-    $typed = Constraints\ObjectConstraint::check($input, $pointer, false);
+    $coerce = false;
+    $typed = Constraints\ObjectConstraint::check($input, $pointer, $coerce);
 
     Constraints\ObjectRequiredConstraint::check($typed, keyset[$key], $pointer);
     $field_pointer = JsonSchema\get_pointer($pointer, $key);

--- a/tests/examples/codegen/PersonSchemaValidator.php
+++ b/tests/examples/codegen/PersonSchemaValidator.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<0e58793fe5eca9c570c3c75b5db0e416>>
+ * @generated SignedSource<<91ebb2683251509f90bb004296968623>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;
@@ -646,8 +646,7 @@ final class PersonSchemaValidatorPropertiesDevicesItems {
     string $pointer,
   ): TPersonSchemaValidatorPropertiesDevicesItems {
     $key = 'type';
-    $coerce = false;
-    $typed = Constraints\ObjectConstraint::check($input, $pointer, $coerce);
+    $typed = Constraints\ObjectConstraint::check($input, $pointer, true);
 
     Constraints\ObjectRequiredConstraint::check($typed, keyset[$key], $pointer);
     $field_pointer = JsonSchema\get_pointer($pointer, $key);
@@ -675,7 +674,7 @@ final class PersonSchemaValidatorPropertiesDevicesItems {
       throw new JsonSchema\InvalidFieldException($field_pointer, vec[$error]);
     }
 
-    return $constraint($typed, $pointer);
+    return $constraint($input, $pointer);
   }
 }
 

--- a/tests/examples/codegen/UntypedSchemaValidator.php
+++ b/tests/examples/codegen/UntypedSchemaValidator.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<af288ef99613b99be842ab276e44eb06>>
+ * @generated SignedSource<<c0576aa98b9a4c6a29bb9015922ecc9e>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;
@@ -78,7 +78,7 @@ type TUntypedSchemaValidator = shape(
 
 final class UntypedSchemaValidatorPropertiesAllOfAllOf0 {
 
-  private static bool $coerce = false;
+  private static bool $coerce = true;
 
   public static function check(mixed $input, string $pointer): string {
     $typed = Constraints\StringConstraint::check($input, $pointer, self::$coerce);
@@ -89,7 +89,7 @@ final class UntypedSchemaValidatorPropertiesAllOfAllOf0 {
 
 final class UntypedSchemaValidatorPropertiesAllOfAllOf1 {
 
-  private static bool $coerce = false;
+  private static bool $coerce = true;
 
   public static function check(mixed $input, string $pointer): int {
     $typed =
@@ -142,7 +142,7 @@ final class UntypedSchemaValidatorPropertiesAllOf {
 
 final class UntypedSchemaValidatorPropertiesAnyOfAnyOf0 {
 
-  private static bool $coerce = false;
+  private static bool $coerce = true;
 
   public static function check(mixed $input, string $pointer): string {
     $typed = Constraints\StringConstraint::check($input, $pointer, self::$coerce);
@@ -153,7 +153,7 @@ final class UntypedSchemaValidatorPropertiesAnyOfAnyOf0 {
 
 final class UntypedSchemaValidatorPropertiesAnyOfAnyOf1 {
 
-  private static bool $coerce = false;
+  private static bool $coerce = true;
 
   public static function check(mixed $input, string $pointer): int {
     $typed =
@@ -201,7 +201,7 @@ final class UntypedSchemaValidatorPropertiesAnyOf {
 
 final class UntypedSchemaValidatorPropertiesAllOfPassThroughAllOf0 {
 
-  private static bool $coerce = false;
+  private static bool $coerce = true;
 
   public static function check(mixed $input, string $pointer): string {
     $typed = Constraints\StringConstraint::check($input, $pointer, self::$coerce);
@@ -217,7 +217,7 @@ final class UntypedSchemaValidatorPropertiesAllOfPassThroughAllOf0 {
 final class UntypedSchemaValidatorPropertiesAllOfPassThroughAllOf1 {
 
   private static int $minLength = 1;
-  private static bool $coerce = false;
+  private static bool $coerce = true;
 
   public static function check(mixed $input, string $pointer): string {
     $typed = Constraints\StringConstraint::check($input, $pointer, self::$coerce);
@@ -275,7 +275,7 @@ final class UntypedSchemaValidatorPropertiesAllOfPassThrough {
 
 final class UntypedSchemaValidatorPropertiesAllOfPassThroughSecondAllOf0 {
 
-  private static bool $coerce = false;
+  private static bool $coerce = true;
 
   public static function check(mixed $input, string $pointer): string {
     $typed = Constraints\StringConstraint::check($input, $pointer, self::$coerce);
@@ -290,7 +290,7 @@ final class UntypedSchemaValidatorPropertiesAllOfPassThroughSecondAllOf0 {
 
 final class UntypedSchemaValidatorPropertiesAllOfPassThroughSecondAllOf1 {
 
-  private static bool $coerce = false;
+  private static bool $coerce = true;
 
   public static function check(mixed $input, string $pointer): string {
     $typed = Constraints\StringConstraint::check($input, $pointer, self::$coerce);
@@ -363,7 +363,7 @@ final class UntypedSchemaValidatorPropertiesAllOfCoerceAllOf0 {
 
 final class UntypedSchemaValidatorPropertiesAllOfCoerceAllOf1PropertiesProperty {
 
-  private static bool $coerce = false;
+  private static bool $coerce = true;
 
   public static function check(mixed $input, string $pointer): string {
     $typed = Constraints\StringConstraint::check($input, $pointer, self::$coerce);
@@ -374,7 +374,7 @@ final class UntypedSchemaValidatorPropertiesAllOfCoerceAllOf1PropertiesProperty 
 
 final class UntypedSchemaValidatorPropertiesAllOfCoerceAllOf1 {
 
-  private static bool $coerce = false;
+  private static bool $coerce = true;
 
   public static function check(
     mixed $input,
@@ -454,7 +454,7 @@ final class UntypedSchemaValidatorPropertiesAllOfCoerce {
 
 final class UntypedSchemaValidatorPropertiesAllOfDefaultAllOf0PropertiesProperty {
 
-  private static bool $coerce = false;
+  private static bool $coerce = true;
 
   public static function check(mixed $input, string $pointer): string {
     $typed = Constraints\StringConstraint::check($input, $pointer, self::$coerce);
@@ -465,7 +465,7 @@ final class UntypedSchemaValidatorPropertiesAllOfDefaultAllOf0PropertiesProperty
 
 final class UntypedSchemaValidatorPropertiesAllOfDefaultAllOf0 {
 
-  private static bool $coerce = false;
+  private static bool $coerce = true;
 
   public static function check(
     mixed $input,
@@ -510,7 +510,7 @@ final class UntypedSchemaValidatorPropertiesAllOfDefaultAllOf0 {
 
 final class UntypedSchemaValidatorPropertiesAllOfDefaultAllOf1PropertiesNumericalProperty {
 
-  private static bool $coerce = false;
+  private static bool $coerce = true;
 
   public static function check(mixed $input, string $pointer): num {
     $typed = Constraints\NumberConstraint::check($input, $pointer, self::$coerce);
@@ -521,7 +521,7 @@ final class UntypedSchemaValidatorPropertiesAllOfDefaultAllOf1PropertiesNumerica
 
 final class UntypedSchemaValidatorPropertiesAllOfDefaultAllOf1 {
 
-  private static bool $coerce = false;
+  private static bool $coerce = true;
 
   public static function check(
     mixed $input,
@@ -607,7 +607,7 @@ final class UntypedSchemaValidatorPropertiesAllOfDefault {
 
 final class UntypedSchemaValidatorPropertiesAllOfDefaultFirstSchemaWinsAllOf0PropertiesProperty {
 
-  private static bool $coerce = false;
+  private static bool $coerce = true;
 
   public static function check(mixed $input, string $pointer): string {
     $typed = Constraints\StringConstraint::check($input, $pointer, self::$coerce);
@@ -618,7 +618,7 @@ final class UntypedSchemaValidatorPropertiesAllOfDefaultFirstSchemaWinsAllOf0Pro
 
 final class UntypedSchemaValidatorPropertiesAllOfDefaultFirstSchemaWinsAllOf0 {
 
-  private static bool $coerce = false;
+  private static bool $coerce = true;
 
   public static function check(
     mixed $input,
@@ -663,7 +663,7 @@ final class UntypedSchemaValidatorPropertiesAllOfDefaultFirstSchemaWinsAllOf0 {
 
 final class UntypedSchemaValidatorPropertiesAllOfDefaultFirstSchemaWinsAllOf1PropertiesProperty {
 
-  private static bool $coerce = false;
+  private static bool $coerce = true;
 
   public static function check(mixed $input, string $pointer): string {
     $typed = Constraints\StringConstraint::check($input, $pointer, self::$coerce);
@@ -674,7 +674,7 @@ final class UntypedSchemaValidatorPropertiesAllOfDefaultFirstSchemaWinsAllOf1Pro
 
 final class UntypedSchemaValidatorPropertiesAllOfDefaultFirstSchemaWinsAllOf1 {
 
-  private static bool $coerce = false;
+  private static bool $coerce = true;
 
   public static function check(
     mixed $input,
@@ -763,7 +763,7 @@ final class UntypedSchemaValidatorPropertiesAnyOfOptimizedEnumAnyOfTypesFirstPro
   private static vec<mixed> $enum = vec[
     'first',
   ];
-  private static bool $coerce = false;
+  private static bool $coerce = true;
 
   public static function check(mixed $input, string $pointer): string {
     $typed = Constraints\StringConstraint::check($input, $pointer, self::$coerce);
@@ -775,7 +775,7 @@ final class UntypedSchemaValidatorPropertiesAnyOfOptimizedEnumAnyOfTypesFirstPro
 
 final class UntypedSchemaValidatorPropertiesAnyOfOptimizedEnumAnyOfTypesFirstPropertiesString {
 
-  private static bool $coerce = false;
+  private static bool $coerce = true;
 
   public static function check(mixed $input, string $pointer): string {
     $typed = Constraints\StringConstraint::check($input, $pointer, self::$coerce);
@@ -861,7 +861,7 @@ final class UntypedSchemaValidatorPropertiesAnyOfOptimizedEnumAnyOfTypesSecondPr
   private static vec<mixed> $enum = vec[
     'second',
   ];
-  private static bool $coerce = false;
+  private static bool $coerce = true;
 
   public static function check(mixed $input, string $pointer): string {
     $typed = Constraints\StringConstraint::check($input, $pointer, self::$coerce);
@@ -873,7 +873,7 @@ final class UntypedSchemaValidatorPropertiesAnyOfOptimizedEnumAnyOfTypesSecondPr
 
 final class UntypedSchemaValidatorPropertiesAnyOfOptimizedEnumAnyOfTypesSecondPropertiesInteger {
 
-  private static bool $coerce = false;
+  private static bool $coerce = true;
 
   public static function check(mixed $input, string $pointer): int {
     $typed =
@@ -962,8 +962,7 @@ final class UntypedSchemaValidatorPropertiesAnyOfOptimizedEnum {
     string $pointer,
   ): TUntypedSchemaValidatorPropertiesAnyOfOptimizedEnum {
     $key = 'type';
-    $coerce = false;
-    $typed = Constraints\ObjectConstraint::check($input, $pointer, $coerce);
+    $typed = Constraints\ObjectConstraint::check($input, $pointer, true);
 
     Constraints\ObjectRequiredConstraint::check($typed, keyset[$key], $pointer);
     $field_pointer = JsonSchema\get_pointer($pointer, $key);
@@ -991,14 +990,14 @@ final class UntypedSchemaValidatorPropertiesAnyOfOptimizedEnum {
       throw new JsonSchema\InvalidFieldException($field_pointer, vec[$error]);
     }
 
-    return $constraint($typed, $pointer);
+    return $constraint($input, $pointer);
   }
 }
 
 final class UntypedSchemaValidator
   extends JsonSchema\BaseValidator<TUntypedSchemaValidator> {
 
-  private static bool $coerce = false;
+  private static bool $coerce = true;
 
   public static function check(
     mixed $input,

--- a/tests/examples/codegen/UntypedSchemaValidator.php
+++ b/tests/examples/codegen/UntypedSchemaValidator.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<307dd9e864c92ca6b69a2c4d5156158f>>
+ * @generated SignedSource<<af288ef99613b99be842ab276e44eb06>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;
@@ -962,7 +962,8 @@ final class UntypedSchemaValidatorPropertiesAnyOfOptimizedEnum {
     string $pointer,
   ): TUntypedSchemaValidatorPropertiesAnyOfOptimizedEnum {
     $key = 'type';
-    $typed = Constraints\ObjectConstraint::check($input, $pointer, false);
+    $coerce = false;
+    $typed = Constraints\ObjectConstraint::check($input, $pointer, $coerce);
 
     Constraints\ObjectRequiredConstraint::check($typed, keyset[$key], $pointer);
     $field_pointer = JsonSchema\get_pointer($pointer, $key);

--- a/tests/examples/untyped-schema.json
+++ b/tests/examples/untyped-schema.json
@@ -117,6 +117,7 @@
           "type": "object",
           "required": ["type"],
           "additionalProperties": false,
+          "coerce": false,
           "properties": {
             "type": {
               "type": "string",
@@ -131,6 +132,7 @@
           "type": "object",
           "required": ["type"],
           "additionalProperties": false,
+          "coerce": false,
           "properties": {
             "type": {
               "type": "string",


### PR DESCRIPTION
Currently, optimized `anyOf` constraints do not correctly handle the case where a constraint coerces strings to objects. This is because the `anyOf` constraint first validates the input is an object, disallowing coercion. Instead, we should validate the input is an object, _allowing coercion_, and then pass the un-coerced input to each constraint. This way, if no constraint allows string-to-object coercion, the `anyOf` constraint will fail, but if at least one does the `anyOf` constraint will pass.