### PR TITLE
Type NullBuilder correctly

### DIFF
--- a/src/Codegen/Constraints/NullBuilder.php
+++ b/src/Codegen/Constraints/NullBuilder.php
@@ -41,7 +41,7 @@ class NullBuilder extends BaseBuilder<TNullSchema> {
 
   <<__Override>>
   public function getType(): string {
-    return 'mixed';
+    return 'null';
   }
 
 }

--- a/src/Constraints/NullConstraint.php
+++ b/src/Constraints/NullConstraint.php
@@ -5,8 +5,8 @@ namespace Slack\Hack\JsonSchema\Constraints;
 use namespace Slack\Hack\JsonSchema;
 
 class NullConstraint {
-  public static function check(mixed $input, string $pointer): mixed {
-    if ($input === null) {
+  public static function check(mixed $input, string $pointer): null {
+    if ($input is null) {
       return $input;
     } else {
       $error = shape(

--- a/tests/examples/codegen/AnyOfValidator3.php
+++ b/tests/examples/codegen/AnyOfValidator3.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<f75639f4e8e44660c38760a9b0e53aa6>>
+ * @generated SignedSource<<d77b8264266f73d1a54d15323844b5c1>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;
@@ -15,7 +15,7 @@ type TAnyOfValidator3 = mixed;
 
 final class AnyOfValidator3AnyOf0 {
 
-  public static function check(mixed $input, string $pointer): mixed {
+  public static function check(mixed $input, string $pointer): null {
     $typed = Constraints\NullConstraint::check($input, $pointer);
 
     return $typed;
@@ -24,7 +24,7 @@ final class AnyOfValidator3AnyOf0 {
 
 final class AnyOfValidator3AnyOf1 {
 
-  public static function check(mixed $input, string $pointer): mixed {
+  public static function check(mixed $input, string $pointer): null {
     $typed = Constraints\NullConstraint::check($input, $pointer);
 
     return $typed;

--- a/tests/examples/codegen/FriendsSchemaValidator.php
+++ b/tests/examples/codegen/FriendsSchemaValidator.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<c1e1a034a097914b540fefaa46b64ab6>>
+ * @generated SignedSource<<401cc11f57c0dbcdfeb500b3e2a606f7>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;
@@ -24,7 +24,7 @@ type TFriendsSchemaValidatorItems = shape(
   'last_name' => string,
   ?'age' => int,
   ?'~devices/' => vec<TFriendsSchemaValidatorItemsPropertiesNanDevicesNanItems>,
-  ?'enemies' => mixed,
+  ?'enemies' => null,
   ?'rating' => vec<mixed>,
   ?'contact' => vec<mixed>,
   ?'empty_object' => TFriendsSchemaValidatorItemsPropertiesEmptyObject,
@@ -185,7 +185,7 @@ final class FriendsSchemaValidatorItemsPropertiesNanDevicesNan {
 
 final class FriendsSchemaValidatorItemsPropertiesEnemies {
 
-  public static function check(mixed $input, string $pointer): mixed {
+  public static function check(mixed $input, string $pointer): null {
     $typed = Constraints\NullConstraint::check($input, $pointer);
 
     return $typed;


### PR DESCRIPTION
In testing https://github.com/slackhq/hack-json-schema/pull/67, I realized that I was dealing with a decent amount of noise form changing the return type of `NullBuilder.` So I'm opening a separate PR for this change, which I'll incorporate downstream before trying to land https://github.com/slackhq/hack-json-schema/pull/67.