### PR TITLE
Bugfix: Alias merged allOf checks to the merged schema type

### DIFF
--- a/src/Codegen/Constraints/UntypedBuilder.php
+++ b/src/Codegen/Constraints/UntypedBuilder.php
@@ -337,6 +337,7 @@ class UntypedBuilder extends BaseBuilder<TUntypedSchema> {
   private function generateMergedAllOfChecks(TSchema $schema, HackBuilder $hb): void {
     $schema_builder = new SchemaBuilder($this->ctx, $this->generateClassName($this->suffix, 'allOf'), $schema);
     $schema_builder->build();
+    $this->type_info = $schema_builder->getTypeInfo();
     $hb->addReturnf('%s::check($input, $pointer)', $schema_builder->getClassName());
   }
 

--- a/tests/examples/codegen/ExamplesAllofSchema1.php
+++ b/tests/examples/codegen/ExamplesAllofSchema1.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<d86fe60f9a4b277d13542c3017f28e35>>
+ * @generated SignedSource<<391cff06fb3f584b3ca4670e891301d7>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;
@@ -16,7 +16,7 @@ type TExamplesAllofSchema1AllOf = shape(
   'foo' => int,
 );
 
-type TExamplesAllofSchema1 = mixed;
+type TExamplesAllofSchema1 = TExamplesAllofSchema1AllOf;
 
 final class ExamplesAllofSchema1AllOfPropertiesBar {
 

--- a/tests/examples/codegen/ExamplesAllofSchema2.php
+++ b/tests/examples/codegen/ExamplesAllofSchema2.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<337da92c52d98e9210c707a6ff9bd4a9>>
+ * @generated SignedSource<<aaac02e5d111884d1e116a9c82ca0dad>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;
@@ -17,7 +17,7 @@ type TExamplesAllofSchema2AllOfPropertiesXsItemsAllOf = shape(
   'foo' => int,
 );
 
-type TExamplesAllofSchema2AllOfPropertiesXsItems = mixed;
+type TExamplesAllofSchema2AllOfPropertiesXsItems = TExamplesAllofSchema2AllOfPropertiesXsItemsAllOf;
 
 type TExamplesAllofSchema2AllOfPropertiesSimpleObjectProp2 = shape(
   'prop_1' => int,
@@ -33,7 +33,7 @@ type TExamplesAllofSchema2AllOf = shape(
   'foo' => int,
 );
 
-type TExamplesAllofSchema2 = mixed;
+type TExamplesAllofSchema2 = TExamplesAllofSchema2AllOf;
 
 final class ExamplesAllofSchema2AllOfPropertiesBaz {
 


### PR DESCRIPTION
https://github.com/slackhq/hack-json-schema/pull/67 introduced a regression in which we stopped aliasing the type generated by merging an `allOf` check as the type of the merged schema.

This fixes the regression by aliasing the `allOf` constraint to the merged constraint's type.