### PR TITLE
Support type inference for oneOf schemas

### DIFF
--- a/src/Codegen/Constraints/UntypedBuilder.php
+++ b/src/Codegen/Constraints/UntypedBuilder.php
@@ -11,7 +11,7 @@ use type Facebook\HackCodegen\{
   HackBuilderKeys,
   HackBuilderValues,
 };
-use type Slack\Hack\JsonSchema\Sentinal;
+use type Slack\Hack\JsonSchema\Sentinel;
 
 type TUntypedSchema = shape(
   ?'anyOf' => vec<TSchema>,
@@ -169,8 +169,8 @@ class UntypedBuilder extends BaseBuilder<TUntypedSchema> {
     $hb
       ->addAssignment('$passed_any', false, HackBuilderValues::export())
       ->addAssignment('$passed_multi', false, HackBuilderValues::export())
-      // Use `sentinal` rather than `null` so that it's obvious when we failed to match any constraint.
-      ->addAssignment('$output', Str\format('\%s::get()', Sentinal::class), HackBuilderValues::literal())
+      // Use `Sentinel` rather than `null` so that it's obvious when we failed to match any constraint.
+      ->addAssignment('$output', Str\format('\%s::get()', Sentinel::class), HackBuilderValues::literal())
       ->startForeachLoop('$constraints', null, '$constraint')
       ->startTryBlock()
       ->addMultilineCall('$output = $constraint', vec['$input', '$pointer'])
@@ -193,7 +193,7 @@ class UntypedBuilder extends BaseBuilder<TUntypedSchema> {
     );
 
     $hb
-      ->startIfBlockf('$passed_multi || !$passed_any || $output is \%s', Sentinal::class)
+      ->startIfBlockf('$passed_multi || !$passed_any || $output is \%s', Sentinel::class)
       ->addAssignment(
         '$error',
         $error,

--- a/src/Codegen/Constraints/UntypedBuilder.php
+++ b/src/Codegen/Constraints/UntypedBuilder.php
@@ -170,7 +170,7 @@ class UntypedBuilder extends BaseBuilder<TUntypedSchema> {
       ->addAssignment('$passed_any', false, HackBuilderValues::export())
       ->addAssignment('$passed_multi', false, HackBuilderValues::export())
       // Use `sentinal` rather than `null` so that it's obvious when we failed to match any constraint.
-      ->addAssignment('$output', Str\format('new \%s()', Sentinal::class), HackBuilderValues::literal())
+      ->addAssignment('$output', Str\format('\%s::get()', Sentinal::class), HackBuilderValues::literal())
       ->startForeachLoop('$constraints', null, '$constraint')
       ->startTryBlock()
       ->addMultilineCall('$output = $constraint', vec['$input', '$pointer'])

--- a/src/Codegen/Constraints/UntypedBuilder.php
+++ b/src/Codegen/Constraints/UntypedBuilder.php
@@ -11,6 +11,7 @@ use type Facebook\HackCodegen\{
   HackBuilderKeys,
   HackBuilderValues,
 };
+use type Slack\Hack\JsonSchema\Sentinal;
 
 type TUntypedSchema = shape(
   ?'anyOf' => vec<TSchema>,
@@ -141,15 +142,25 @@ class UntypedBuilder extends BaseBuilder<TUntypedSchema> {
 
   }
 
-  // TODO: Determine Lowest Upper Bound for oneOf constraint.
   private function generateOneOfChecks(vec<TSchema> $schemas, HackBuilder $hb): void {
     $constraints = vec[];
+    $types = vec[];
     foreach ($schemas as $index => $schema) {
       $schema_builder =
         new SchemaBuilder($this->ctx, $this->generateClassName($this->suffix, 'oneOf', (string)$index), $schema);
       $schema_builder->build();
       $constraints[] = "{$schema_builder->getClassName()}::check<>";
+      $types[] = $schema_builder->getTypeInfo();
     }
+
+    $type_info = Typing\TypeSystem::union($types);
+    // For now, keep upcasting nonnull to mixed.
+    // This is a temporary cludge to reduce the amount of code changed by generating unions.
+    // TODO: Stop doing the above.
+    if ($type_info is Typing\ConcreteType && $type_info->getConcreteTypeName() === Typing\ConcreteTypeName::NONNULL) {
+      $type_info = Typing\TypeSystem::mixed();
+    }
+    $this->type_info = $type_info;
 
     $hb
       ->addAssignment('$constraints', $constraints, HackBuilderValues::vec(HackBuilderValues::literal()))
@@ -158,7 +169,8 @@ class UntypedBuilder extends BaseBuilder<TUntypedSchema> {
     $hb
       ->addAssignment('$passed_any', false, HackBuilderValues::export())
       ->addAssignment('$passed_multi', false, HackBuilderValues::export())
-      ->addAssignment('$output', null, HackBuilderValues::export())
+      // Use `sentinal` rather than `null` so that it's obvious when we failed to match any constraint.
+      ->addAssignment('$output', Str\format('new \%s()', Sentinal::class), HackBuilderValues::literal())
       ->startForeachLoop('$constraints', null, '$constraint')
       ->startTryBlock()
       ->addMultilineCall('$output = $constraint', vec['$input', '$pointer'])
@@ -181,7 +193,7 @@ class UntypedBuilder extends BaseBuilder<TUntypedSchema> {
     );
 
     $hb
-      ->startIfBlock('$passed_multi || !$passed_any')
+      ->startIfBlockf('$passed_multi || !$passed_any || $output is \%s', Sentinal::class)
       ->addAssignment(
         '$error',
         $error,
@@ -452,7 +464,7 @@ class UntypedBuilder extends BaseBuilder<TUntypedSchema> {
 
               if ($property_type === TSchemaType::STRING_T && C\contains($required, $property_name)) {
                 $typed_property_schema =
-                  type_assert_shape($property_schema, 'Slack\Hack\JsonSchema\Codegen\TStringSchema');
+                  type_assert_type($property_schema, \Slack\Hack\JsonSchema\Codegen\TStringSchema::class);
 
                 $enum = $typed_property_schema['enum'] ?? null;
                 if ($enum is nonnull && C\count($enum) === 1) {

--- a/src/Sentinal.hack
+++ b/src/Sentinal.hack
@@ -1,0 +1,6 @@
+namespace Slack\Hack\JsonSchema;
+
+/**
+ * Represents an unset value.
+ */
+final class Sentinal {}

--- a/src/Sentinal.hack
+++ b/src/Sentinal.hack
@@ -3,4 +3,14 @@ namespace Slack\Hack\JsonSchema;
 /**
  * Represents an unset value.
  */
-final class Sentinal {}
+final class Sentinal {
+
+    /**
+     * The singleton instance of the sentinal value.
+     */
+    public static function get(): this {
+        return new self();
+    }
+
+    private function __construct () {}
+}

--- a/src/Sentinel.hack
+++ b/src/Sentinel.hack
@@ -3,7 +3,7 @@ namespace Slack\Hack\JsonSchema;
 /**
  * Represents an unset value.
  */
-final class Sentinal {
+final class Sentinel {
 
     /**
      * The singleton instance of the sentinal value.

--- a/tests/DiscardAddititionalPropertiesValidatorTest.php
+++ b/tests/DiscardAddititionalPropertiesValidatorTest.php
@@ -10,10 +10,7 @@ final class DiscardAddititionalPropertiesValidatorTest extends BaseCodegenTestCa
 
   <<__Override>>
   public static async function beforeFirstTestAsync(): Awaitable<void> {
-    $ret = self::getBuilder(
-      'discard-additional-properties-schema.json',
-      'DiscardAddititionalPropertiesValidator',
-    );
+    $ret = self::getBuilder('discard-additional-properties-schema.json', 'DiscardAddititionalPropertiesValidator');
     $ret['codegen']->build();
     require_once($ret['path']);
   }

--- a/tests/UntypedSchemaValidatorTest.php
+++ b/tests/UntypedSchemaValidatorTest.php
@@ -202,4 +202,36 @@ final class UntypedSchemaValidatorTest extends BaseCodegenTestCase {
     expect($error['pointer'] ?? null)->toBeSame('/any_of_optimized_enum');
   }
 
+  public function testOneOfNullableString(): void {
+    $this->expectCases(
+      vec[
+        shape('input' => 'foo', 'output' => dict['one_of_nullable_string' => 'foo'], 'valid' => true),
+        shape('input' => null, 'output' => dict['one_of_nullable_string' => null], 'valid' => true),
+        shape('input' => true, 'valid' => false),
+      ],
+      $input ==> new UntypedSchemaValidator(dict['one_of_nullable_string' => $input]),
+    );
+  }
+
+  public function testOneOfStringAndInt(): void {
+    $this->expectCases(
+      vec[
+        shape('input' => 'foo', 'output' => dict['one_of_string_and_int' => 'foo'], 'valid' => true),
+        shape('input' => 3, 'output' => dict['one_of_string_and_int' => 3], 'valid' => true),
+        shape('input' => true, 'valid' => false),
+      ],
+      $input ==> new UntypedSchemaValidator(dict['one_of_string_and_int' => $input]),
+    );
+  }
+
+  public function testOneOfStringAndVec(): void {
+    $this->expectCases(
+      vec[
+        shape('input' => 'foo', 'output' => dict['one_of_string_and_vec' => 'foo'], 'valid' => true),
+        shape('input' => vec[3], 'output' => dict['one_of_string_and_vec' => vec[3]], 'valid' => true),
+        shape('input' => 3, 'valid' => false),
+      ],
+      $input ==> new UntypedSchemaValidator(dict['one_of_string_and_vec' => $input]),
+    );
+  }
 }

--- a/tests/examples/codegen/AddressSchemaValidator.php
+++ b/tests/examples/codegen/AddressSchemaValidator.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<f55b7686ddc5695a203819aec8bb8742>>
+ * @generated SignedSource<<884da88463b70fac29468fab117c4e1b>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;
@@ -23,7 +23,7 @@ type TAddressSchemaValidatorPropertiesSize = mixed;
 
 type TAddressSchemaValidatorPropertiesLongitude = mixed;
 
-type TAddressSchemaValidatorPropertiesLatitude = mixed;
+type TAddressSchemaValidatorPropertiesLatitude = num;
 
 type TAddressSchemaValidator = shape(
   ?'post-office-box' => string,
@@ -425,7 +425,7 @@ final class AddressSchemaValidatorPropertiesLatitude {
 
     $passed_any = false;
     $passed_multi = false;
-    $output = null;
+    $output = new \Slack\Hack\JsonSchema\Sentinal();
     foreach ($constraints as $constraint) {
       try {
         $output = $constraint($input, $pointer);
@@ -438,7 +438,7 @@ final class AddressSchemaValidatorPropertiesLatitude {
       }
     }
 
-    if ($passed_multi || !$passed_any) {
+    if ($passed_multi || !$passed_any || $output is \Slack\Hack\JsonSchema\Sentinal) {
       $error = shape(
         'code' => JsonSchema\FieldErrorCode::FAILED_CONSTRAINT,
         'constraint' => shape(

--- a/tests/examples/codegen/AddressSchemaValidator.php
+++ b/tests/examples/codegen/AddressSchemaValidator.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<884da88463b70fac29468fab117c4e1b>>
+ * @generated SignedSource<<7c546e3edf3430be1044abfffdf398cd>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;
@@ -425,7 +425,7 @@ final class AddressSchemaValidatorPropertiesLatitude {
 
     $passed_any = false;
     $passed_multi = false;
-    $output = new \Slack\Hack\JsonSchema\Sentinal();
+    $output = \Slack\Hack\JsonSchema\Sentinal::get();
     foreach ($constraints as $constraint) {
       try {
         $output = $constraint($input, $pointer);

--- a/tests/examples/codegen/AddressSchemaValidator.php
+++ b/tests/examples/codegen/AddressSchemaValidator.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<7c546e3edf3430be1044abfffdf398cd>>
+ * @generated SignedSource<<bbd4e20ed2f469e62e0efcc5610d2ccc>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;
@@ -425,7 +425,7 @@ final class AddressSchemaValidatorPropertiesLatitude {
 
     $passed_any = false;
     $passed_multi = false;
-    $output = \Slack\Hack\JsonSchema\Sentinal::get();
+    $output = \Slack\Hack\JsonSchema\Sentinel::get();
     foreach ($constraints as $constraint) {
       try {
         $output = $constraint($input, $pointer);
@@ -438,7 +438,7 @@ final class AddressSchemaValidatorPropertiesLatitude {
       }
     }
 
-    if ($passed_multi || !$passed_any || $output is \Slack\Hack\JsonSchema\Sentinal) {
+    if ($passed_multi || !$passed_any || $output is \Slack\Hack\JsonSchema\Sentinel) {
       $error = shape(
         'code' => JsonSchema\FieldErrorCode::FAILED_CONSTRAINT,
         'constraint' => shape(

--- a/tests/examples/codegen/UntypedSchemaValidator.php
+++ b/tests/examples/codegen/UntypedSchemaValidator.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<90a3ca75ea51b3a416f721e6eb1828de>>
+ * @generated SignedSource<<8553bd28dc52954a5c87a8c2cb2f3b01>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;
@@ -1036,7 +1036,7 @@ final class UntypedSchemaValidatorPropertiesOneOfNullableString {
 
     $passed_any = false;
     $passed_multi = false;
-    $output = new \Slack\Hack\JsonSchema\Sentinal();
+    $output = \Slack\Hack\JsonSchema\Sentinal::get();
     foreach ($constraints as $constraint) {
       try {
         $output = $constraint($input, $pointer);
@@ -1099,7 +1099,7 @@ final class UntypedSchemaValidatorPropertiesOneOfStringAndInt {
 
     $passed_any = false;
     $passed_multi = false;
-    $output = new \Slack\Hack\JsonSchema\Sentinal();
+    $output = \Slack\Hack\JsonSchema\Sentinal::get();
     foreach ($constraints as $constraint) {
       try {
         $output = $constraint($input, $pointer);
@@ -1191,7 +1191,7 @@ final class UntypedSchemaValidatorPropertiesOneOfStringAndVec {
 
     $passed_any = false;
     $passed_multi = false;
-    $output = new \Slack\Hack\JsonSchema\Sentinal();
+    $output = \Slack\Hack\JsonSchema\Sentinal::get();
     foreach ($constraints as $constraint) {
       try {
         $output = $constraint($input, $pointer);

--- a/tests/examples/codegen/UntypedSchemaValidator.php
+++ b/tests/examples/codegen/UntypedSchemaValidator.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<8553bd28dc52954a5c87a8c2cb2f3b01>>
+ * @generated SignedSource<<e7f10e1ede65035fb26f7fa52cba5e5f>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;
@@ -1036,7 +1036,7 @@ final class UntypedSchemaValidatorPropertiesOneOfNullableString {
 
     $passed_any = false;
     $passed_multi = false;
-    $output = \Slack\Hack\JsonSchema\Sentinal::get();
+    $output = \Slack\Hack\JsonSchema\Sentinel::get();
     foreach ($constraints as $constraint) {
       try {
         $output = $constraint($input, $pointer);
@@ -1049,7 +1049,7 @@ final class UntypedSchemaValidatorPropertiesOneOfNullableString {
       }
     }
 
-    if ($passed_multi || !$passed_any || $output is \Slack\Hack\JsonSchema\Sentinal) {
+    if ($passed_multi || !$passed_any || $output is \Slack\Hack\JsonSchema\Sentinel) {
       $error = shape(
         'code' => JsonSchema\FieldErrorCode::FAILED_CONSTRAINT,
         'constraint' => shape(
@@ -1099,7 +1099,7 @@ final class UntypedSchemaValidatorPropertiesOneOfStringAndInt {
 
     $passed_any = false;
     $passed_multi = false;
-    $output = \Slack\Hack\JsonSchema\Sentinal::get();
+    $output = \Slack\Hack\JsonSchema\Sentinel::get();
     foreach ($constraints as $constraint) {
       try {
         $output = $constraint($input, $pointer);
@@ -1112,7 +1112,7 @@ final class UntypedSchemaValidatorPropertiesOneOfStringAndInt {
       }
     }
 
-    if ($passed_multi || !$passed_any || $output is \Slack\Hack\JsonSchema\Sentinal) {
+    if ($passed_multi || !$passed_any || $output is \Slack\Hack\JsonSchema\Sentinel) {
       $error = shape(
         'code' => JsonSchema\FieldErrorCode::FAILED_CONSTRAINT,
         'constraint' => shape(
@@ -1191,7 +1191,7 @@ final class UntypedSchemaValidatorPropertiesOneOfStringAndVec {
 
     $passed_any = false;
     $passed_multi = false;
-    $output = \Slack\Hack\JsonSchema\Sentinal::get();
+    $output = \Slack\Hack\JsonSchema\Sentinel::get();
     foreach ($constraints as $constraint) {
       try {
         $output = $constraint($input, $pointer);
@@ -1204,7 +1204,7 @@ final class UntypedSchemaValidatorPropertiesOneOfStringAndVec {
       }
     }
 
-    if ($passed_multi || !$passed_any || $output is \Slack\Hack\JsonSchema\Sentinal) {
+    if ($passed_multi || !$passed_any || $output is \Slack\Hack\JsonSchema\Sentinel) {
       $error = shape(
         'code' => JsonSchema\FieldErrorCode::FAILED_CONSTRAINT,
         'constraint' => shape(

--- a/tests/examples/codegen/UntypedSchemaValidator.php
+++ b/tests/examples/codegen/UntypedSchemaValidator.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<25dc59f6b0554fb484fa23d884432464>>
+ * @generated SignedSource<<90a3ca75ea51b3a416f721e6eb1828de>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;
@@ -64,6 +64,12 @@ type TUntypedSchemaValidatorPropertiesAnyOfOptimizedEnumAnyOfTypesSecond = shape
 
 type TUntypedSchemaValidatorPropertiesAnyOfOptimizedEnum = mixed;
 
+type TUntypedSchemaValidatorPropertiesOneOfNullableString = ?string;
+
+type TUntypedSchemaValidatorPropertiesOneOfStringAndInt = arraykey;
+
+type TUntypedSchemaValidatorPropertiesOneOfStringAndVec = mixed;
+
 type TUntypedSchemaValidator = shape(
   ?'all_of' => TUntypedSchemaValidatorPropertiesAllOf,
   ?'any_of' => TUntypedSchemaValidatorPropertiesAnyOf,
@@ -73,6 +79,9 @@ type TUntypedSchemaValidator = shape(
   ?'all_of_default' => TUntypedSchemaValidatorPropertiesAllOfDefault,
   ?'all_of_default_first_schema_wins' => TUntypedSchemaValidatorPropertiesAllOfDefaultFirstSchemaWins,
   ?'any_of_optimized_enum' => TUntypedSchemaValidatorPropertiesAnyOfOptimizedEnum,
+  ?'one_of_nullable_string' => TUntypedSchemaValidatorPropertiesOneOfNullableString,
+  ?'one_of_string_and_int' => TUntypedSchemaValidatorPropertiesOneOfStringAndInt,
+  ?'one_of_string_and_vec' => TUntypedSchemaValidatorPropertiesOneOfStringAndVec,
   ...
 );
 
@@ -994,6 +1003,221 @@ final class UntypedSchemaValidatorPropertiesAnyOfOptimizedEnum {
   }
 }
 
+final class UntypedSchemaValidatorPropertiesOneOfNullableStringOneOf0 {
+
+  public static function check(mixed $input, string $pointer): null {
+    $typed = Constraints\NullConstraint::check($input, $pointer);
+
+    return $typed;
+  }
+}
+
+final class UntypedSchemaValidatorPropertiesOneOfNullableStringOneOf1 {
+
+  private static bool $coerce = true;
+
+  public static function check(mixed $input, string $pointer): string {
+    $typed = Constraints\StringConstraint::check($input, $pointer, self::$coerce);
+
+    return $typed;
+  }
+}
+
+final class UntypedSchemaValidatorPropertiesOneOfNullableString {
+
+  public static function check(
+    mixed $input,
+    string $pointer,
+  ): TUntypedSchemaValidatorPropertiesOneOfNullableString {
+    $constraints = vec[
+      UntypedSchemaValidatorPropertiesOneOfNullableStringOneOf0::check<>,
+      UntypedSchemaValidatorPropertiesOneOfNullableStringOneOf1::check<>,
+    ];
+
+    $passed_any = false;
+    $passed_multi = false;
+    $output = new \Slack\Hack\JsonSchema\Sentinal();
+    foreach ($constraints as $constraint) {
+      try {
+        $output = $constraint($input, $pointer);
+        if ($passed_any) {
+          $passed_multi = true;
+          break;
+        }
+        $passed_any = true;
+      } catch (JsonSchema\InvalidFieldException $e) {
+      }
+    }
+
+    if ($passed_multi || !$passed_any || $output is \Slack\Hack\JsonSchema\Sentinal) {
+      $error = shape(
+        'code' => JsonSchema\FieldErrorCode::FAILED_CONSTRAINT,
+        'constraint' => shape(
+          'type' => JsonSchema\FieldErrorConstraint::ONE_OF,
+        ),
+        'message' => 'failed to match exactly one allowed schema',
+      );
+      throw new JsonSchema\InvalidFieldException($pointer, vec[$error]);
+    }
+    return $output;
+  }
+}
+
+final class UntypedSchemaValidatorPropertiesOneOfStringAndIntOneOf0 {
+
+  private static bool $coerce = true;
+
+  public static function check(mixed $input, string $pointer): int {
+    $typed =
+      Constraints\IntegerConstraint::check($input, $pointer, self::$coerce);
+
+    return $typed;
+  }
+}
+
+final class UntypedSchemaValidatorPropertiesOneOfStringAndIntOneOf1 {
+
+  private static bool $coerce = false;
+
+  public static function check(mixed $input, string $pointer): string {
+    $typed = Constraints\StringConstraint::check($input, $pointer, self::$coerce);
+
+    return $typed;
+  }
+}
+
+final class UntypedSchemaValidatorPropertiesOneOfStringAndInt {
+
+  public static function check(
+    mixed $input,
+    string $pointer,
+  ): TUntypedSchemaValidatorPropertiesOneOfStringAndInt {
+    $constraints = vec[
+      UntypedSchemaValidatorPropertiesOneOfStringAndIntOneOf0::check<>,
+      UntypedSchemaValidatorPropertiesOneOfStringAndIntOneOf1::check<>,
+    ];
+
+    $passed_any = false;
+    $passed_multi = false;
+    $output = new \Slack\Hack\JsonSchema\Sentinal();
+    foreach ($constraints as $constraint) {
+      try {
+        $output = $constraint($input, $pointer);
+        if ($passed_any) {
+          $passed_multi = true;
+          break;
+        }
+        $passed_any = true;
+      } catch (JsonSchema\InvalidFieldException $e) {
+      }
+    }
+
+    if ($passed_multi || !$passed_any || $output is \Slack\Hack\JsonSchema\Sentinal) {
+      $error = shape(
+        'code' => JsonSchema\FieldErrorCode::FAILED_CONSTRAINT,
+        'constraint' => shape(
+          'type' => JsonSchema\FieldErrorConstraint::ONE_OF,
+        ),
+        'message' => 'failed to match exactly one allowed schema',
+      );
+      throw new JsonSchema\InvalidFieldException($pointer, vec[$error]);
+    }
+    return $output;
+  }
+}
+
+final class UntypedSchemaValidatorPropertiesOneOfStringAndVecOneOf0 {
+
+  private static bool $coerce = false;
+
+  public static function check(mixed $input, string $pointer): string {
+    $typed = Constraints\StringConstraint::check($input, $pointer, self::$coerce);
+
+    return $typed;
+  }
+}
+
+final class UntypedSchemaValidatorPropertiesOneOfStringAndVecOneOf1Items {
+
+  private static bool $coerce = true;
+
+  public static function check(mixed $input, string $pointer): int {
+    $typed =
+      Constraints\IntegerConstraint::check($input, $pointer, self::$coerce);
+
+    return $typed;
+  }
+}
+
+final class UntypedSchemaValidatorPropertiesOneOfStringAndVecOneOf1 {
+
+  private static bool $coerce = true;
+
+  public static function check(mixed $input, string $pointer): vec<int> {
+    $typed = Constraints\ArrayConstraint::check($input, $pointer, self::$coerce);
+
+    $output = vec[];
+    $errors = vec[];
+
+    foreach ($typed as $index => $value) {
+      try {
+        $output[] = UntypedSchemaValidatorPropertiesOneOfStringAndVecOneOf1Items::check(
+          $value,
+          JsonSchema\get_pointer($pointer, (string) $index),
+        );
+      } catch (JsonSchema\InvalidFieldException $e) {
+        $errors = \HH\Lib\Vec\concat($errors, $e->errors);
+      }
+    }
+
+    if (\HH\Lib\C\count($errors)) {
+      throw new JsonSchema\InvalidFieldException($pointer, $errors);
+    }
+
+    return $output;
+  }
+}
+
+final class UntypedSchemaValidatorPropertiesOneOfStringAndVec {
+
+  public static function check(
+    mixed $input,
+    string $pointer,
+  ): TUntypedSchemaValidatorPropertiesOneOfStringAndVec {
+    $constraints = vec[
+      UntypedSchemaValidatorPropertiesOneOfStringAndVecOneOf0::check<>,
+      UntypedSchemaValidatorPropertiesOneOfStringAndVecOneOf1::check<>,
+    ];
+
+    $passed_any = false;
+    $passed_multi = false;
+    $output = new \Slack\Hack\JsonSchema\Sentinal();
+    foreach ($constraints as $constraint) {
+      try {
+        $output = $constraint($input, $pointer);
+        if ($passed_any) {
+          $passed_multi = true;
+          break;
+        }
+        $passed_any = true;
+      } catch (JsonSchema\InvalidFieldException $e) {
+      }
+    }
+
+    if ($passed_multi || !$passed_any || $output is \Slack\Hack\JsonSchema\Sentinal) {
+      $error = shape(
+        'code' => JsonSchema\FieldErrorCode::FAILED_CONSTRAINT,
+        'constraint' => shape(
+          'type' => JsonSchema\FieldErrorConstraint::ONE_OF,
+        ),
+        'message' => 'failed to match exactly one allowed schema',
+      );
+      throw new JsonSchema\InvalidFieldException($pointer, vec[$error]);
+    }
+    return $output;
+  }
+}
+
 final class UntypedSchemaValidator
   extends JsonSchema\BaseValidator<TUntypedSchemaValidator> {
 
@@ -1096,6 +1320,39 @@ final class UntypedSchemaValidator
         $output['any_of_optimized_enum'] = UntypedSchemaValidatorPropertiesAnyOfOptimizedEnum::check(
           $typed['any_of_optimized_enum'],
           JsonSchema\get_pointer($pointer, 'any_of_optimized_enum'),
+        );
+      } catch (JsonSchema\InvalidFieldException $e) {
+        $errors = \HH\Lib\Vec\concat($errors, $e->errors);
+      }
+    }
+
+    if (\HH\Lib\C\contains_key($typed, 'one_of_nullable_string')) {
+      try {
+        $output['one_of_nullable_string'] = UntypedSchemaValidatorPropertiesOneOfNullableString::check(
+          $typed['one_of_nullable_string'],
+          JsonSchema\get_pointer($pointer, 'one_of_nullable_string'),
+        );
+      } catch (JsonSchema\InvalidFieldException $e) {
+        $errors = \HH\Lib\Vec\concat($errors, $e->errors);
+      }
+    }
+
+    if (\HH\Lib\C\contains_key($typed, 'one_of_string_and_int')) {
+      try {
+        $output['one_of_string_and_int'] = UntypedSchemaValidatorPropertiesOneOfStringAndInt::check(
+          $typed['one_of_string_and_int'],
+          JsonSchema\get_pointer($pointer, 'one_of_string_and_int'),
+        );
+      } catch (JsonSchema\InvalidFieldException $e) {
+        $errors = \HH\Lib\Vec\concat($errors, $e->errors);
+      }
+    }
+
+    if (\HH\Lib\C\contains_key($typed, 'one_of_string_and_vec')) {
+      try {
+        $output['one_of_string_and_vec'] = UntypedSchemaValidatorPropertiesOneOfStringAndVec::check(
+          $typed['one_of_string_and_vec'],
+          JsonSchema\get_pointer($pointer, 'one_of_string_and_vec'),
         );
       } catch (JsonSchema\InvalidFieldException $e) {
         $errors = \HH\Lib\Vec\concat($errors, $e->errors);

--- a/tests/examples/untyped-schema.json
+++ b/tests/examples/untyped-schema.json
@@ -144,6 +144,41 @@
           }
         }
       ]
+    },
+    "one_of_nullable_string": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "one_of_string_and_int": {
+      "oneOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "string",
+          "coerce": false
+        }
+      ]
+    },
+    "one_of_string_and_vec": {
+      "oneOf": [
+        {
+          "type": "string",
+          "coerce": false
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
Support for type inference for non-shape types in oneOf constraints. Shapes are still unsupported, just as they are unsupported for anyOf. They're a fair bit of work to get right and will come later, if we deem that worthwhile.