### PR TITLE
Generate Nonnull Types for Unions

### DIFF
--- a/src/Codegen/Constraints/UntypedBuilder.php
+++ b/src/Codegen/Constraints/UntypedBuilder.php
@@ -153,14 +153,7 @@ class UntypedBuilder extends BaseBuilder<TUntypedSchema> {
       $types[] = $schema_builder->getTypeInfo();
     }
 
-    $type_info = Typing\TypeSystem::union($types);
-    // For now, keep upcasting nonnull to mixed.
-    // This is a temporary cludge to reduce the amount of code changed by generating unions.
-    // TODO: Stop doing the above.
-    if ($type_info is Typing\ConcreteType && $type_info->getConcreteTypeName() === Typing\ConcreteTypeName::NONNULL) {
-      $type_info = Typing\TypeSystem::mixed();
-    }
-    $this->type_info = $type_info;
+    $this->type_info = Typing\TypeSystem::union($types);
 
     $hb
       ->addAssignment('$constraints', $constraints, HackBuilderValues::vec(HackBuilderValues::literal()))
@@ -510,17 +503,8 @@ class UntypedBuilder extends BaseBuilder<TUntypedSchema> {
       }
     }
 
-    $type_info = Typing\TypeSystem::union($present_types);
-    // For now, keep upcasting nonnull to mixed.
-    // This is a temporary cludge to reduce the amount of code changed by generating unions.
-    // TODO: Stop doing the above.
-    if ($type_info is Typing\ConcreteType && $type_info->getConcreteTypeName() === Typing\ConcreteTypeName::NONNULL) {
-      $type_info = Typing\TypeSystem::mixed();
-    }
-    $this->type_info = $type_info;
-    if (C\count($nonnull_builders) < C\count($schema_builders)) {
-      // If we filtered out a null builder above, handle it here.
-      // TODO: Once we remove the above cludge, we can do `if ($this->type_info->isOptional()) {`
+    $this->type_info = Typing\TypeSystem::union($present_types);
+    if ($this->type_info->isOptional()) {
       $hb
         ->startIfBlock('$input === null')
         ->addReturn(null, HackBuilderValues::export())

--- a/src/Sentinel.hack
+++ b/src/Sentinel.hack
@@ -8,6 +8,7 @@ final class Sentinel {
     /**
      * The singleton instance of the sentinal value.
      */
+    <<__Memoize>>
     public static function get(): this {
         return new self();
     }

--- a/tests/examples/codegen/AnyOfValidator2.php
+++ b/tests/examples/codegen/AnyOfValidator2.php
@@ -5,13 +5,13 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<72449b6279d0ca5b12355b69be8582b1>>
+ * @generated SignedSource<<99b51d66245aaffdf4a13563142ea5f5>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;
 use namespace Slack\Hack\JsonSchema\Constraints;
 
-type TAnyOfValidator2 = mixed;
+type TAnyOfValidator2 = nonnull;
 
 final class AnyOfValidator2AnyOf0 {
 

--- a/tests/examples/codegen/AnyOfValidatorNestedNullableAnyOf.php
+++ b/tests/examples/codegen/AnyOfValidatorNestedNullableAnyOf.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<caed5ad653fe7f7d3dfe0516296d4e6b>>
+ * @generated SignedSource<<c1940fa688271ce27b41f85f8b502a40>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;
@@ -84,6 +84,10 @@ final class AnyOfValidatorNestedNullableAnyOf
     mixed $input,
     string $pointer,
   ): TAnyOfValidatorNestedNullableAnyOf {
+    if ($input === null) {
+      return null;
+    }
+
     $constraints = vec[
       AnyOfValidatorNestedNullableAnyOfAnyOf0::check<>,
       AnyOfValidatorNestedNullableAnyOfAnyOf1::check<>,

--- a/tests/examples/codegen/AnyOfValidatorShapes.php
+++ b/tests/examples/codegen/AnyOfValidatorShapes.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<fa85e2dfb2ba253b0d8d4d4bf3885c14>>
+ * @generated SignedSource<<0a79c5a2b4cdbd407b5c69fb9125b3ed>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;
@@ -20,7 +20,7 @@ type TAnyOfValidatorShapesAnyOf1 = shape(
   ?'foo' => string,
 );
 
-type TAnyOfValidatorShapes = mixed;
+type TAnyOfValidatorShapes = nonnull;
 
 final class AnyOfValidatorShapesAnyOf0PropertiesFoo {
 

--- a/tests/examples/codegen/UntypedSchemaValidator.php
+++ b/tests/examples/codegen/UntypedSchemaValidator.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<e7f10e1ede65035fb26f7fa52cba5e5f>>
+ * @generated SignedSource<<2c98b928d525db21c6948ef14b310a05>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;
@@ -68,7 +68,7 @@ type TUntypedSchemaValidatorPropertiesOneOfNullableString = ?string;
 
 type TUntypedSchemaValidatorPropertiesOneOfStringAndInt = arraykey;
 
-type TUntypedSchemaValidatorPropertiesOneOfStringAndVec = mixed;
+type TUntypedSchemaValidatorPropertiesOneOfStringAndVec = nonnull;
 
 type TUntypedSchemaValidator = shape(
   ?'all_of' => TUntypedSchemaValidatorPropertiesAllOf,


### PR DESCRIPTION
This is a backport.

Here, we generate nonnull types for fake "union" types (since Hack doesn't actually have unions). This removes a cludge we had in place to upcast nonnull to mixed.