### PR TITLE
Fix codegen for empty shapes

### DIFF
--- a/src/Codegen/Constraints/ObjectBuilder.php
+++ b/src/Codegen/Constraints/ObjectBuilder.php
@@ -153,7 +153,7 @@ class ObjectBuilder extends BaseBuilder<TObjectSchema> {
       $hb->addInlineComment('Hack to prevent us from having to change the params names when we are not using them.');
       $hb->addAssignment('$_', '$input', HackBuilderValues::literal());
       $hb->addAssignment('$_', '$pointer', HackBuilderValues::literal());
-      $hb->addReturn('dict[]', HackBuilderValues::literal());
+      $hb->addReturn('shape()', HackBuilderValues::literal());
 
       return $hb;
     }

--- a/tests/ObjectSchemaValidatorTest.php
+++ b/tests/ObjectSchemaValidatorTest.php
@@ -698,23 +698,15 @@ final class ObjectSchemaValidatorTest extends BaseCodegenTestCase {
     ]);
     $validator->validate();
     expect($validator->isValid())->toBeTrue();
+    expect($validator->getValidatedInput())->toEqual(shape());
 
+    // Additional properties are discarded
     $validator = new ObjectSchemaValidator(dict[
       'empty_closed_shape' => dict['foo' => 'bar']
     ]);
     $validator->validate();
-    expect($validator->isValid())->toBeFalse();
-
-    $errors = $validator->getErrors();
-    expect(C\count($errors))->toEqual(1);
-
-    $error = C\firstx($errors);
-    expect($error['code'])->toEqual(FieldErrorCode::FAILED_CONSTRAINT);
-    expect($error['message'])->toEqual('invalid additional property: foo');
-
-    $constraint = Shapes::at($error, 'constraint');
-    expect($constraint['type'])->toEqual(FieldErrorConstraint::ADDITIONAL_PROPERTIES);
-    expect($constraint['got'] ?? null)->toEqual('foo');
+    expect($validator->isValid())->toBeTrue();
+    expect($validator->getValidatedInput())->toEqual(shape());
   }
 
 }

--- a/tests/ObjectSchemaValidatorTest.php
+++ b/tests/ObjectSchemaValidatorTest.php
@@ -698,7 +698,7 @@ final class ObjectSchemaValidatorTest extends BaseCodegenTestCase {
     ]);
     $validator->validate();
     expect($validator->isValid())->toBeTrue();
-    expect($validator->getValidatedInput())->toEqual(shape());
+    expect($validator->getValidatedInput())->toEqual(shape('empty_closed_shape' => shape()));
 
     // Additional properties are discarded
     $validator = new ObjectSchemaValidator(dict[
@@ -706,7 +706,7 @@ final class ObjectSchemaValidatorTest extends BaseCodegenTestCase {
     ]);
     $validator->validate();
     expect($validator->isValid())->toBeTrue();
-    expect($validator->getValidatedInput())->toEqual(shape());
+    expect($validator->getValidatedInput())->toEqual(shape('empty_closed_shape' => shape()));
   }
 
 }

--- a/tests/ObjectSchemaValidatorTest.php
+++ b/tests/ObjectSchemaValidatorTest.php
@@ -692,4 +692,29 @@ final class ObjectSchemaValidatorTest extends BaseCodegenTestCase {
     expect($constraint['got'] ?? null)->toEqual('a');
   }
 
+  public function testEmptyClosedShape(): void {
+    $validator = new ObjectSchemaValidator(dict[
+      'empty_closed_shape' => dict[]
+    ]);
+    $validator->validate();
+    expect($validator->isValid())->toBeTrue();
+
+    $validator = new ObjectSchemaValidator(dict[
+      'empty_closed_shape' => dict['foo' => 'bar']
+    ]);
+    $validator->validate();
+    expect($validator->isValid())->toBeFalse();
+
+    $errors = $validator->getErrors();
+    expect(C\count($errors))->toEqual(1);
+
+    $error = C\firstx($errors);
+    expect($error['code'])->toEqual(FieldErrorCode::FAILED_CONSTRAINT);
+    expect($error['message'])->toEqual('invalid additional property: foo');
+
+    $constraint = Shapes::at($error, 'constraint');
+    expect($constraint['type'])->toEqual(FieldErrorConstraint::ADDITIONAL_PROPERTIES);
+    expect($constraint['got'] ?? null)->toEqual('foo');
+  }
+
 }

--- a/tests/examples/codegen/ObjectSchemaValidator.php
+++ b/tests/examples/codegen/ObjectSchemaValidator.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<5d8158e850af0f6d550037bc4003da67>>
+ * @generated SignedSource<<39430f90b530b5635008632715853853>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;
@@ -1662,33 +1662,11 @@ final class ObjectSchemaValidatorPropertiesEmptyClosedShape {
     mixed $input,
     string $pointer,
   ): TObjectSchemaValidatorPropertiesEmptyClosedShape {
-    $typed = Constraints\ObjectConstraint::check($input, $pointer, self::$coerce);
-
-    $errors = vec[];
-    $output = shape();
-
-    /*HHAST_IGNORE_ERROR[UnusedVariable] Some loops generated with this statement do not use their $value*/
-    foreach ($typed as $key => $value) {
-      if (\HH\Lib\C\contains_key(self::$properties, $key)) {
-        continue;
-      }
-
-      $errors[] = shape(
-        'code' => JsonSchema\FieldErrorCode::FAILED_CONSTRAINT,
-        'message' => "invalid additional property: {$key}",
-        'constraint' => shape(
-          'type' => JsonSchema\FieldErrorConstraint::ADDITIONAL_PROPERTIES,
-          'got' => $key,
-        ),
-      );
-    }
-
-    if (\HH\Lib\C\count($errors)) {
-      throw new JsonSchema\InvalidFieldException($pointer, $errors);
-    }
-
-    /* HH_IGNORE_ERROR[4163] */
-    return $output;
+    // Hack to prevent us from having to change the params names when we are not
+    // using them.
+    $_ = $input;
+    $_ = $pointer;
+    return shape();
   }
 }
 

--- a/tests/examples/codegen/ObjectSchemaValidator.php
+++ b/tests/examples/codegen/ObjectSchemaValidator.php
@@ -5,7 +5,7 @@
  * To re-generate this file run `make test`
  *
  *
- * @generated SignedSource<<7fa7d1f5ae7e84bf34ab173568728f05>>
+ * @generated SignedSource<<5d8158e850af0f6d550037bc4003da67>>
  */
 namespace Slack\Hack\JsonSchema\Tests\Generated;
 use namespace Slack\Hack\JsonSchema;
@@ -97,6 +97,9 @@ type TObjectSchemaValidatorPropertiesMinAndMaxProperties = dict<string, mixed>;
 
 type TObjectSchemaValidatorPropertiesInvalidMinPropertiesWithNoAdditionalProperties = dict<string, mixed>;
 
+type TObjectSchemaValidatorPropertiesEmptyClosedShape = shape(
+);
+
 type TObjectSchemaValidator = shape(
   ?'only_additional_properties' => TObjectSchemaValidatorPropertiesOnlyAdditionalProperties,
   ?'only_no_additional_properties' => TObjectSchemaValidatorPropertiesOnlyNoAdditionalProperties,
@@ -119,6 +122,7 @@ type TObjectSchemaValidator = shape(
   ?'only_max_properties' => TObjectSchemaValidatorPropertiesOnlyMaxProperties,
   ?'min_and_max_properties' => TObjectSchemaValidatorPropertiesMinAndMaxProperties,
   ?'invalid_min_properties_with_no_additional_properties' => TObjectSchemaValidatorPropertiesInvalidMinPropertiesWithNoAdditionalProperties,
+  ?'empty_closed_shape' => TObjectSchemaValidatorPropertiesEmptyClosedShape,
   ...
 );
 
@@ -1648,6 +1652,46 @@ final class ObjectSchemaValidatorPropertiesInvalidMinPropertiesWithNoAdditionalP
   }
 }
 
+final class ObjectSchemaValidatorPropertiesEmptyClosedShape {
+
+  private static bool $coerce = false;
+  private static keyset<string> $properties = keyset[
+  ];
+
+  public static function check(
+    mixed $input,
+    string $pointer,
+  ): TObjectSchemaValidatorPropertiesEmptyClosedShape {
+    $typed = Constraints\ObjectConstraint::check($input, $pointer, self::$coerce);
+
+    $errors = vec[];
+    $output = shape();
+
+    /*HHAST_IGNORE_ERROR[UnusedVariable] Some loops generated with this statement do not use their $value*/
+    foreach ($typed as $key => $value) {
+      if (\HH\Lib\C\contains_key(self::$properties, $key)) {
+        continue;
+      }
+
+      $errors[] = shape(
+        'code' => JsonSchema\FieldErrorCode::FAILED_CONSTRAINT,
+        'message' => "invalid additional property: {$key}",
+        'constraint' => shape(
+          'type' => JsonSchema\FieldErrorConstraint::ADDITIONAL_PROPERTIES,
+          'got' => $key,
+        ),
+      );
+    }
+
+    if (\HH\Lib\C\count($errors)) {
+      throw new JsonSchema\InvalidFieldException($pointer, $errors);
+    }
+
+    /* HH_IGNORE_ERROR[4163] */
+    return $output;
+  }
+}
+
 final class ObjectSchemaValidator
   extends JsonSchema\BaseValidator<TObjectSchemaValidator> {
 
@@ -1893,6 +1937,17 @@ final class ObjectSchemaValidator
         $output['invalid_min_properties_with_no_additional_properties'] = ObjectSchemaValidatorPropertiesInvalidMinPropertiesWithNoAdditionalProperties::check(
           $typed['invalid_min_properties_with_no_additional_properties'],
           JsonSchema\get_pointer($pointer, 'invalid_min_properties_with_no_additional_properties'),
+        );
+      } catch (JsonSchema\InvalidFieldException $e) {
+        $errors = \HH\Lib\Vec\concat($errors, $e->errors);
+      }
+    }
+
+    if (\HH\Lib\C\contains_key($typed, 'empty_closed_shape')) {
+      try {
+        $output['empty_closed_shape'] = ObjectSchemaValidatorPropertiesEmptyClosedShape::check(
+          $typed['empty_closed_shape'],
+          JsonSchema\get_pointer($pointer, 'empty_closed_shape'),
         );
       } catch (JsonSchema\InvalidFieldException $e) {
         $errors = \HH\Lib\Vec\concat($errors, $e->errors);

--- a/tests/examples/object-schema.json
+++ b/tests/examples/object-schema.json
@@ -180,7 +180,7 @@
     "empty_closed_shape": {
       "type": "object",
       "additionalProperties": false,
-      "discardAdditionalProperties": false,
+      "discardAdditionalProperties": true,
       "properties": {}
     }
   }

--- a/tests/examples/object-schema.json
+++ b/tests/examples/object-schema.json
@@ -176,6 +176,12 @@
       "type": "object",
       "minProperties": 1,
       "additionalProperties": false
+    },
+    "empty_closed_shape": {
+      "type": "object",
+      "additionalProperties": false,
+      "discardAdditionalProperties": false,
+      "properties": {}
     }
   }
 }


### PR DESCRIPTION
We were returning `dict[]` from functions typed as returning empty shapes. Sort of surprising this only just came up, but here's the fix.