### PR TITLE
Add support for generating hack enums from json def

### DIFF
--- a/src/Codegen/Constraints/BaseBuilder.php
+++ b/src/Codegen/Constraints/BaseBuilder.php
@@ -7,171 +7,177 @@ use type Facebook\HackCodegen\{CodegenClass, CodegenMethod, CodegenProperty, Hac
 
 <<__ConsistentConstruct>>
 abstract class BaseBuilder<T> implements IBuilder {
-  use Factory;
+	use Factory;
 
-  protected T $typed_schema;
-  protected static string $schema_name = '';
+	protected T $typed_schema;
+	protected static string $schema_name = '';
 
-  public function __construct(
-    protected Context $ctx,
-    protected string $suffix,
-    protected TSchema $schema,
-    protected ?CodegenClass $class = null,
-  ) {
-    $this->typed_schema = type_assert_shape($this->schema, static::$schema_name);
-  }
+	public function __construct(
+		protected Context $ctx,
+		protected string $suffix,
+		protected TSchema $schema,
+		protected ?CodegenClass $class = null,
+	) {
+		$this->typed_schema = type_assert_shape($this->schema, static::$schema_name);
+	}
 
-  /**
-  *
-  * Return a string which will get rendered as a literal value describing the
-  * output type of the schema. For example, the `StringBuilder` would return:
-  * `return 'string';`, the `NumberBuilder` would return: `return 'num';`.
-  */
-  abstract public function getType(): string;
+	/**
+	*
+	* Return a string which will get rendered as a literal value describing the
+	* output type of the schema. For example, the `StringBuilder` would return:
+	* `return 'string';`, the `NumberBuilder` would return: `return 'num';`.
+	*/
+	abstract public function getType(): string;
 
-  public function isArrayKeyType(): bool {
-    $type = $this->getType();
-    if ($type === 'string' || $type === 'int') {
-      return true;
-    }
+	public function isArrayKeyType(): bool {
+		$type = $this->getType();
+		if ($type === 'string' || $type === 'int') {
+			return true;
+		}
 
-    $schema = type_assert_type($this->typed_schema, TSchema::class);
-    return Shapes::keyExists($schema, 'hackEnum');
-  }
+		$schema = type_assert_type($this->typed_schema, TSchema::class);
+		return Shapes::keyExists($schema, 'hackEnum');
+	}
 
-  /**
-  *
-  * Main method for building the class for the schema and appending it to the
-  * file.
-  */
-  abstract public function build(): this;
+	/**
+	*
+	* Main method for building the class for the schema and appending it to the
+	* file.
+	*/
+	abstract public function build(): this;
 
-  protected function getHackBuilder(): HackBuilder {
-    return new HackBuilder($this->ctx->getHackCodegenFactory()->getConfig());
-  }
+	protected function getHackBuilder(): HackBuilder {
+		return new HackBuilder($this->ctx->getHackCodegenFactory()->getConfig());
+	}
 
-  public function getClassName(): string {
-    return $this->generateClassName($this->ctx->getClassName(), $this->suffix);
-  }
+	public function getClassName(): string {
+		return $this->generateClassName($this->ctx->getClassName(), $this->suffix);
+	}
 
-  protected function codegenClass(): CodegenClass {
-    if ($this->class) {
-      return $this->class;
-    }
+	protected function codegenClass(): CodegenClass {
+		if ($this->class) {
+			return $this->class;
+		}
 
-    return $this->ctx
-      ->getHackCodegenFactory()
-      ->codegenClass($this->getClassName())
-      ->setIsFinal(true);
-  }
+		return $this->ctx
+			->getHackCodegenFactory()
+			->codegenClass($this->getClassName())
+			->setIsFinal(true);
+	}
 
-  protected function codegenProperty(string $name): CodegenProperty {
-    return $this->ctx
-      ->getHackCodegenFactory()
-      ->codegenProperty($name)
-      ->setIsStatic(true)
-      ->setPrivate();
-  }
+	protected function codegenProperty(string $name): CodegenProperty {
+		return $this->ctx
+			->getHackCodegenFactory()
+			->codegenProperty($name)
+			->setIsStatic(true)
+			->setPrivate();
+	}
 
-  protected function codegenCheckMethod(): CodegenMethod {
-    return $this->ctx
-      ->getHackCodegenFactory()
-      ->codegenMethod('check')
-      ->setPublic()
-      ->setIsStatic(true);
-  }
+	protected function codegenCheckMethod(): CodegenMethod {
+		return $this->ctx
+			->getHackCodegenFactory()
+			->codegenMethod('check')
+			->setPublic()
+			->setIsStatic(true);
+	}
 
-  protected function getEnumCodegenProperty(): ?CodegenProperty {
-    $property = null;
-    $schema = type_assert_shape($this->typed_schema, 'Slack\Hack\JsonSchema\Codegen\TSchema');
-    $enum = $schema['enum'] ?? null;
-    if ($enum is nonnull) {
-      $hb = $this->getHackBuilder()
-        ->addValue($enum, HackBuilderValues::vec(HackBuilderValues::export()));
+	protected function getEnumCodegenProperty(): ?CodegenProperty {
+		$property = null;
+		$schema = type_assert_shape($this->typed_schema, 'Slack\Hack\JsonSchema\Codegen\TSchema');
+		$enum = $schema['enum'] ?? null;
+		if ($enum is nonnull) {
+			$hb = $this->getHackBuilder()
+				->addValue($enum, HackBuilderValues::vec(HackBuilderValues::export()));
 
-      $property = $this->codegenProperty('enum')
-        ->setType('vec<mixed>')
-        ->setValue($hb->getCode(), HackBuilderValues::literal());
-    }
-    return $property;
-  }
+			$property = $this->codegenProperty('enum')
+				->setType('vec<mixed>')
+				->setValue($hb->getCode(), HackBuilderValues::literal());
+		}
+		return $property;
+	}
 
-  protected function addEnumConstraintCheck(HackBuilder $hb): void {
-    $schema = type_assert_shape($this->typed_schema, 'Slack\Hack\JsonSchema\Codegen\TSchema');
-    if (($schema['enum'] ?? null) is nonnull) {
-      $hb->addMultilineCall('Constraints\EnumConstraint::check', vec['$typed', 'self::$enum', '$pointer']);
-    }
-  }
+	protected function addEnumConstraintCheck(HackBuilder $hb): void {
+		$schema = type_assert_shape($this->typed_schema, 'Slack\Hack\JsonSchema\Codegen\TSchema');
+		if (($schema['enum'] ?? null) is nonnull) {
+			$hb->addMultilineCall('Constraints\EnumConstraint::check', vec['$typed', 'self::$enum', '$pointer']);
+		}
+	}
 
-  protected function addHackEnumConstraintCheck(HackBuilder $hb): void {
-    $schema = type_assert_type($this->typed_schema, TSchema::class);
-    if (!Shapes::keyExists($schema, 'hackEnum')) {
-      return;
-    }
+	protected function addHackEnumConstraintCheck(HackBuilder $hb): void {
+		$schema = type_assert_type($this->typed_schema, TSchema::class);
+		if (!Shapes::keyExists($schema, 'hackEnum')) {
+			return;
+		}
+		$generateHackEnum = $schema['generateHackEnum'] ?? false;
+		if (!$generateHackEnum) {
 
-    try {
-      $rc = new \ReflectionClass($schema['hackEnum']);
-    } catch (\ReflectionException $e) {
-      throw new \Exception(Str\format("Hack enum '%s' does not exist", $schema['hackEnum']));
-    }
+			try {
+				$rc = new \ReflectionClass($schema['hackEnum']);
+			} catch (\ReflectionException $e) {
+				throw new \Exception(Str\format("Hack enum '%s' does not exist", $schema['hackEnum']));
+			}
 
-    invariant($rc->isEnum(), "'%s' is not an enum", $schema['hackEnum']);
+			invariant($rc->isEnum(), "'%s' is not an enum", $schema['hackEnum']);
 
-    $schema_type = $schema['type'] ?? null;
-    $hack_enum_values = keyset[];
-    foreach ($rc->getConstants() as $hack_enum_value) {
-      if ($schema_type === TSchemaType::INTEGER_T) {
-        $hack_enum_value = $hack_enum_value ?as int;
-      } else {
-        $hack_enum_value = $hack_enum_value ?as string;
-      }
-      invariant(
-        $hack_enum_value is nonnull,
-        "'%s' must contain only values of type %s",
-        $rc->getName(),
-        $schema_type === TSchemaType::INTEGER_T ? 'int' : 'string',
-      );
-      $hack_enum_values[] = $hack_enum_value;
-    }
+			$schema_type = $schema['type'] ?? null;
+			$hack_enum_values = keyset[];
+			foreach ($rc->getConstants() as $hack_enum_value) {
+				if ($schema_type === TSchemaType::INTEGER_T) {
+					$hack_enum_value = $hack_enum_value ?as int;
+				} else {
+					$hack_enum_value = $hack_enum_value ?as string;
+				}
+				invariant(
+					$hack_enum_value is nonnull,
+					"'%s' must contain only values of type %s",
+					$rc->getName(),
+					$schema_type === TSchemaType::INTEGER_T ? 'int' : 'string',
+				);
+				$hack_enum_values[] = $hack_enum_value;
+			}
 
-    if (Shapes::keyExists($schema, 'enum')) {
-      // If both `enum` and `hackEnum` are specified, assert that `enum` is a subset of
-      // `hackEnum` values. Any value not also in `hackEnum` can't be valid.
-      foreach ($schema['enum'] as $enum_value) {
-        invariant(
-          $enum_value is string,
-          "Enum value '%s' is not a valid value for '%s'",
-          \print_r($enum_value, true),
-          $rc->getName(),
-        );
-        invariant(
-          C\contains_key($hack_enum_values, $enum_value),
-          "Enum value '%s' is unexpectedly not present in '%s'",
-          \print_r($enum_value, true),
-          $rc->getName(),
-        );
-      }
-    }
+			if (Shapes::keyExists($schema, 'enum')) {
+				// If both `enum` and `hackEnum` are specified, assert that `enum` is a subset of
+				// `hackEnum` values. Any value not also in `hackEnum` can't be valid.
+				foreach ($schema['enum'] as $enum_value) {
+					invariant(
+						$enum_value is string,
+						"Enum value '%s' is not a valid value for '%s'",
+						\print_r($enum_value, true),
+						$rc->getName(),
+					);
+					invariant(
+						C\contains_key($hack_enum_values, $enum_value),
+						"Enum value '%s' is unexpectedly not present in '%s'",
+						\print_r($enum_value, true),
+						$rc->getName(),
+					);
+				}
+			}
+			$enum_name = $rc->getName();
+		} else {
+			$enum_name = $schema['hackEnum'];
+		}
 
-    $hb->addMultilineCall(
-      '$typed = Constraints\HackEnumConstraint::check',
-      vec[
-        '$typed',
-        Str\format('\%s::class', $rc->getName()),
-        '$pointer',
-      ],
-    );
-  }
+		$hb->addMultilineCall(
+			'$typed = Constraints\HackEnumConstraint::check',
+			vec[
+				'$typed',
+				Str\format('\%s::class', $enum_name),
+				'$pointer',
+			],
+		);
+	}
 
-  public function addBuilderClass(CodegenClass $class): void {
-    if ($this->class) {
-      return;
-    }
+	public function addBuilderClass(CodegenClass $class): void {
+		if ($this->class) {
+			return;
+		}
 
-    $this->ctx->getFile()->addClass($class);
-  }
+		$this->ctx->getFile()->addClass($class);
+	}
 
-  public function setSuffix(string $suffix): void {
-    $this->suffix = $suffix;
-  }
+	public function setSuffix(string $suffix): void {
+		$this->suffix = $suffix;
+	}
 }

--- a/src/Codegen/Constraints/BaseBuilder.php
+++ b/src/Codegen/Constraints/BaseBuilder.php
@@ -3,191 +3,175 @@
 namespace Slack\Hack\JsonSchema\Codegen;
 
 use namespace HH\Lib\{C, Str};
-use type Facebook\HackCodegen\{
-	CodegenClass,
-  // CodegenEnum,
-	CodegenEnumMember,
-	CodegenMethod,
-	CodegenProperty,
-	HackBuilder,
-	HackBuilderValues,
-};
+use type Facebook\HackCodegen\{CodegenClass, CodegenMethod, CodegenProperty, HackBuilder, HackBuilderValues};
 
 <<__ConsistentConstruct>>
 abstract class BaseBuilder<T> implements IBuilder {
-	use Factory;
+  use Factory;
 
-	protected T $typed_schema;
-	protected static string $schema_name = '';
+  protected T $typed_schema;
+  protected static string $schema_name = '';
 
-	public function __construct(
-		protected Context $ctx,
-		protected string $suffix,
-		protected TSchema $schema,
-		protected ?CodegenClass $class = null,
-	) {
-		$this->typed_schema = type_assert_shape($this->schema, static::$schema_name);
-	}
+  public function __construct(
+    protected Context $ctx,
+    protected string $suffix,
+    protected TSchema $schema,
+    protected ?CodegenClass $class = null,
+  ) {
+    $this->typed_schema = type_assert_shape($this->schema, static::$schema_name);
+  }
 
-	/**
-	*
-	* Return a string which will get rendered as a literal value describing the
-	* output type of the schema. For example, the `StringBuilder` would return:
-	* `return 'string';`, the `NumberBuilder` would return: `return 'num';`.
-	*/
-	abstract public function getType(): string;
+  /**
+  *
+  * Return a string which will get rendered as a literal value describing the
+  * output type of the schema. For example, the `StringBuilder` would return:
+  * `return 'string';`, the `NumberBuilder` would return: `return 'num';`.
+  */
+  abstract public function getType(): string;
 
-	public function isArrayKeyType(): bool {
-		$type = $this->getType();
-		if ($type === 'string' || $type === 'int') {
-			return true;
-		}
+  public function isArrayKeyType(): bool {
+    $type = $this->getType();
+    if ($type === 'string' || $type === 'int') {
+      return true;
+    }
 
-		$schema = type_assert_type($this->typed_schema, TSchema::class);
-		return Shapes::keyExists($schema, 'hackEnum');
-	}
+    $schema = type_assert_type($this->typed_schema, TSchema::class);
+    return Shapes::keyExists($schema, 'hackEnum');
+  }
 
-	/**
-	*
-	* Main method for building the class for the schema and appending it to the
-	* file.
-	*/
-	abstract public function build(): this;
+  /**
+  *
+  * Main method for building the class for the schema and appending it to the
+  * file.
+  */
+  abstract public function build(): this;
 
-	protected function getHackBuilder(): HackBuilder {
-		return new HackBuilder($this->ctx->getHackCodegenFactory()->getConfig());
-	}
+  protected function getHackBuilder(): HackBuilder {
+    return new HackBuilder($this->ctx->getHackCodegenFactory()->getConfig());
+  }
 
-	public function getClassName(): string {
-		return $this->generateClassName($this->ctx->getClassName(), $this->suffix);
-	}
+  public function getClassName(): string {
+    return $this->generateClassName($this->ctx->getClassName(), $this->suffix);
+  }
 
-	protected function codegenClass(): CodegenClass {
-		if ($this->class) {
-			return $this->class;
-		}
+  protected function codegenClass(): CodegenClass {
+    if ($this->class) {
+      return $this->class;
+    }
 
-		return $this->ctx
-			->getHackCodegenFactory()
-			->codegenClass($this->getClassName())
-			->setIsFinal(true);
-	}
+    return $this->ctx
+      ->getHackCodegenFactory()
+      ->codegenClass($this->getClassName())
+      ->setIsFinal(true);
+  }
 
-	protected function codegenProperty(string $name): CodegenProperty {
-		return $this->ctx
-			->getHackCodegenFactory()
-			->codegenProperty($name)
-			->setIsStatic(true)
-			->setPrivate();
-	}
+  protected function codegenProperty(string $name): CodegenProperty {
+    return $this->ctx
+      ->getHackCodegenFactory()
+      ->codegenProperty($name)
+      ->setIsStatic(true)
+      ->setPrivate();
+  }
 
-	protected function codegenCheckMethod(): CodegenMethod {
-		return $this->ctx
-			->getHackCodegenFactory()
-			->codegenMethod('check')
-			->setPublic()
-			->setIsStatic(true);
-	}
+  protected function codegenCheckMethod(): CodegenMethod {
+    return $this->ctx
+      ->getHackCodegenFactory()
+      ->codegenMethod('check')
+      ->setPublic()
+      ->setIsStatic(true);
+  }
 
-	protected function getEnumCodegenProperty(): ?CodegenProperty {
-		$property = null;
-		$schema = type_assert_shape($this->typed_schema, 'Slack\Hack\JsonSchema\Codegen\TSchema');
-		$enum = $schema['enum'] ?? null;
-		if ($enum is nonnull) {
-			$should_create_hack_enum = $schema['generateHackEnum'] ?? false;
-			if ($should_create_hack_enum) {
-        $factory = $this->ctx->getHackCodegenFactory()
-				$members = Vec\map($enum, $val ==> $factory->codegenEnumMember($val));
-				$enum_obj = $factory->codegenEnum('enum', 'string')->addMembers($members);
-        $this->codegenProperty('enum')->setType('enum')->setPublic()->setValue($enum_obj->getCode(), HackBuilderValues::literal());
-			} else {
-				$hb = $this->getHackBuilder()
-					->addValue($enum, HackBuilderValues::vec(HackBuilderValues::export()));
+  protected function getEnumCodegenProperty(): ?CodegenProperty {
+    $property = null;
+    $schema = type_assert_shape($this->typed_schema, 'Slack\Hack\JsonSchema\Codegen\TSchema');
+    $enum = $schema['enum'] ?? null;
+    if ($enum is nonnull) {
+      $hb = $this->getHackBuilder()
+        ->addValue($enum, HackBuilderValues::vec(HackBuilderValues::export()));
 
-				$property = $this->codegenProperty('enum')
-					->setType('vec<mixed>')
-					->setValue($hb->getCode(), HackBuilderValues::literal());
-			}
-		}
-		return $property;
-	}
+      $property = $this->codegenProperty('enum')
+        ->setType('vec<mixed>')
+        ->setValue($hb->getCode(), HackBuilderValues::literal());
+    }
+    return $property;
+  }
 
-	protected function addEnumConstraintCheck(HackBuilder $hb): void {
-		$schema = type_assert_shape($this->typed_schema, 'Slack\Hack\JsonSchema\Codegen\TSchema');
-		if (($schema['enum'] ?? null) is nonnull) {
-			$hb->addMultilineCall('Constraints\EnumConstraint::check', vec['$typed', 'self::$enum', '$pointer']);
-		}
-	}
+  protected function addEnumConstraintCheck(HackBuilder $hb): void {
+    $schema = type_assert_shape($this->typed_schema, 'Slack\Hack\JsonSchema\Codegen\TSchema');
+    if (($schema['enum'] ?? null) is nonnull) {
+      $hb->addMultilineCall('Constraints\EnumConstraint::check', vec['$typed', 'self::$enum', '$pointer']);
+    }
+  }
 
-	protected function addHackEnumConstraintCheck(HackBuilder $hb): void {
-		$schema = type_assert_type($this->typed_schema, TSchema::class);
-		if (!Shapes::keyExists($schema, 'hackEnum')) {
-			return;
-		}
+  protected function addHackEnumConstraintCheck(HackBuilder $hb): void {
+    $schema = type_assert_type($this->typed_schema, TSchema::class);
+    if (!Shapes::keyExists($schema, 'hackEnum')) {
+      return;
+    }
 
-		try {
-			$rc = new \ReflectionClass($schema['hackEnum']);
-		} catch (\ReflectionException $e) {
-			throw new \Exception(Str\format("Hack enum '%s' does not exist", $schema['hackEnum']));
-		}
+    try {
+      $rc = new \ReflectionClass($schema['hackEnum']);
+    } catch (\ReflectionException $e) {
+      throw new \Exception(Str\format("Hack enum '%s' does not exist", $schema['hackEnum']));
+    }
 
-		invariant($rc->isEnum(), "'%s' is not an enum", $schema['hackEnum']);
+    invariant($rc->isEnum(), "'%s' is not an enum", $schema['hackEnum']);
 
-		$schema_type = $schema['type'] ?? null;
-		$hack_enum_values = keyset[];
-		foreach ($rc->getConstants() as $hack_enum_value) {
-			if ($schema_type === TSchemaType::INTEGER_T) {
-				$hack_enum_value = $hack_enum_value ?as int;
-			} else {
-				$hack_enum_value = $hack_enum_value ?as string;
-			}
-			invariant(
-				$hack_enum_value is nonnull,
-				"'%s' must contain only values of type %s",
-				$rc->getName(),
-				$schema_type === TSchemaType::INTEGER_T ? 'int' : 'string',
-			);
-			$hack_enum_values[] = $hack_enum_value;
-		}
+    $schema_type = $schema['type'] ?? null;
+    $hack_enum_values = keyset[];
+    foreach ($rc->getConstants() as $hack_enum_value) {
+      if ($schema_type === TSchemaType::INTEGER_T) {
+        $hack_enum_value = $hack_enum_value ?as int;
+      } else {
+        $hack_enum_value = $hack_enum_value ?as string;
+      }
+      invariant(
+        $hack_enum_value is nonnull,
+        "'%s' must contain only values of type %s",
+        $rc->getName(),
+        $schema_type === TSchemaType::INTEGER_T ? 'int' : 'string',
+      );
+      $hack_enum_values[] = $hack_enum_value;
+    }
 
-		if (Shapes::keyExists($schema, 'enum')) {
-			// If both `enum` and `hackEnum` are specified, assert that `enum` is a subset of
-			// `hackEnum` values. Any value not also in `hackEnum` can't be valid.
-			foreach ($schema['enum'] as $enum_value) {
-				invariant(
-					$enum_value is string,
-					"Enum value '%s' is not a valid value for '%s'",
-					\print_r($enum_value, true),
-					$rc->getName(),
-				);
-				invariant(
-					C\contains_key($hack_enum_values, $enum_value),
-					"Enum value '%s' is unexpectedly not present in '%s'",
-					\print_r($enum_value, true),
-					$rc->getName(),
-				);
-			}
-		}
+    if (Shapes::keyExists($schema, 'enum')) {
+      // If both `enum` and `hackEnum` are specified, assert that `enum` is a subset of
+      // `hackEnum` values. Any value not also in `hackEnum` can't be valid.
+      foreach ($schema['enum'] as $enum_value) {
+        invariant(
+          $enum_value is string,
+          "Enum value '%s' is not a valid value for '%s'",
+          \print_r($enum_value, true),
+          $rc->getName(),
+        );
+        invariant(
+          C\contains_key($hack_enum_values, $enum_value),
+          "Enum value '%s' is unexpectedly not present in '%s'",
+          \print_r($enum_value, true),
+          $rc->getName(),
+        );
+      }
+    }
 
-		$hb->addMultilineCall(
-			'$typed = Constraints\HackEnumConstraint::check',
-			vec[
-				'$typed',
-				Str\format('\%s::class', $rc->getName()),
-				'$pointer',
-			],
-		);
-	}
+    $hb->addMultilineCall(
+      '$typed = Constraints\HackEnumConstraint::check',
+      vec[
+        '$typed',
+        Str\format('\%s::class', $rc->getName()),
+        '$pointer',
+      ],
+    );
+  }
 
-	public function addBuilderClass(CodegenClass $class): void {
-		if ($this->class) {
-			return;
-		}
+  public function addBuilderClass(CodegenClass $class): void {
+    if ($this->class) {
+      return;
+    }
 
-		$this->ctx->getFile()->addClass($class);
-	}
+    $this->ctx->getFile()->addClass($class);
+  }
 
-	public function setSuffix(string $suffix): void {
-		$this->suffix = $suffix;
-	}
+  public function setSuffix(string $suffix): void {
+    $this->suffix = $suffix;
+  }
 }

--- a/src/Codegen/Constraints/BaseBuilder.php
+++ b/src/Codegen/Constraints/BaseBuilder.php
@@ -3,175 +3,191 @@
 namespace Slack\Hack\JsonSchema\Codegen;
 
 use namespace HH\Lib\{C, Str};
-use type Facebook\HackCodegen\{CodegenClass, CodegenMethod, CodegenProperty, HackBuilder, HackBuilderValues};
+use type Facebook\HackCodegen\{
+	CodegenClass,
+  // CodegenEnum,
+	CodegenEnumMember,
+	CodegenMethod,
+	CodegenProperty,
+	HackBuilder,
+	HackBuilderValues,
+};
 
 <<__ConsistentConstruct>>
 abstract class BaseBuilder<T> implements IBuilder {
-  use Factory;
+	use Factory;
 
-  protected T $typed_schema;
-  protected static string $schema_name = '';
+	protected T $typed_schema;
+	protected static string $schema_name = '';
 
-  public function __construct(
-    protected Context $ctx,
-    protected string $suffix,
-    protected TSchema $schema,
-    protected ?CodegenClass $class = null,
-  ) {
-    $this->typed_schema = type_assert_shape($this->schema, static::$schema_name);
-  }
+	public function __construct(
+		protected Context $ctx,
+		protected string $suffix,
+		protected TSchema $schema,
+		protected ?CodegenClass $class = null,
+	) {
+		$this->typed_schema = type_assert_shape($this->schema, static::$schema_name);
+	}
 
-  /**
-  *
-  * Return a string which will get rendered as a literal value describing the
-  * output type of the schema. For example, the `StringBuilder` would return:
-  * `return 'string';`, the `NumberBuilder` would return: `return 'num';`.
-  */
-  abstract public function getType(): string;
+	/**
+	*
+	* Return a string which will get rendered as a literal value describing the
+	* output type of the schema. For example, the `StringBuilder` would return:
+	* `return 'string';`, the `NumberBuilder` would return: `return 'num';`.
+	*/
+	abstract public function getType(): string;
 
-  public function isArrayKeyType(): bool {
-    $type = $this->getType();
-    if ($type === 'string' || $type === 'int') {
-      return true;
-    }
+	public function isArrayKeyType(): bool {
+		$type = $this->getType();
+		if ($type === 'string' || $type === 'int') {
+			return true;
+		}
 
-    $schema = type_assert_type($this->typed_schema, TSchema::class);
-    return Shapes::keyExists($schema, 'hackEnum');
-  }
+		$schema = type_assert_type($this->typed_schema, TSchema::class);
+		return Shapes::keyExists($schema, 'hackEnum');
+	}
 
-  /**
-  *
-  * Main method for building the class for the schema and appending it to the
-  * file.
-  */
-  abstract public function build(): this;
+	/**
+	*
+	* Main method for building the class for the schema and appending it to the
+	* file.
+	*/
+	abstract public function build(): this;
 
-  protected function getHackBuilder(): HackBuilder {
-    return new HackBuilder($this->ctx->getHackCodegenFactory()->getConfig());
-  }
+	protected function getHackBuilder(): HackBuilder {
+		return new HackBuilder($this->ctx->getHackCodegenFactory()->getConfig());
+	}
 
-  public function getClassName(): string {
-    return $this->generateClassName($this->ctx->getClassName(), $this->suffix);
-  }
+	public function getClassName(): string {
+		return $this->generateClassName($this->ctx->getClassName(), $this->suffix);
+	}
 
-  protected function codegenClass(): CodegenClass {
-    if ($this->class) {
-      return $this->class;
-    }
+	protected function codegenClass(): CodegenClass {
+		if ($this->class) {
+			return $this->class;
+		}
 
-    return $this->ctx
-      ->getHackCodegenFactory()
-      ->codegenClass($this->getClassName())
-      ->setIsFinal(true);
-  }
+		return $this->ctx
+			->getHackCodegenFactory()
+			->codegenClass($this->getClassName())
+			->setIsFinal(true);
+	}
 
-  protected function codegenProperty(string $name): CodegenProperty {
-    return $this->ctx
-      ->getHackCodegenFactory()
-      ->codegenProperty($name)
-      ->setIsStatic(true)
-      ->setPrivate();
-  }
+	protected function codegenProperty(string $name): CodegenProperty {
+		return $this->ctx
+			->getHackCodegenFactory()
+			->codegenProperty($name)
+			->setIsStatic(true)
+			->setPrivate();
+	}
 
-  protected function codegenCheckMethod(): CodegenMethod {
-    return $this->ctx
-      ->getHackCodegenFactory()
-      ->codegenMethod('check')
-      ->setPublic()
-      ->setIsStatic(true);
-  }
+	protected function codegenCheckMethod(): CodegenMethod {
+		return $this->ctx
+			->getHackCodegenFactory()
+			->codegenMethod('check')
+			->setPublic()
+			->setIsStatic(true);
+	}
 
-  protected function getEnumCodegenProperty(): ?CodegenProperty {
-    $property = null;
-    $schema = type_assert_shape($this->typed_schema, 'Slack\Hack\JsonSchema\Codegen\TSchema');
-    $enum = $schema['enum'] ?? null;
-    if ($enum is nonnull) {
-      $hb = $this->getHackBuilder()
-        ->addValue($enum, HackBuilderValues::vec(HackBuilderValues::export()));
+	protected function getEnumCodegenProperty(): ?CodegenProperty {
+		$property = null;
+		$schema = type_assert_shape($this->typed_schema, 'Slack\Hack\JsonSchema\Codegen\TSchema');
+		$enum = $schema['enum'] ?? null;
+		if ($enum is nonnull) {
+			$should_create_hack_enum = $schema['generateHackEnum'] ?? false;
+			if ($should_create_hack_enum) {
+        $factory = $this->ctx->getHackCodegenFactory()
+				$members = Vec\map($enum, $val ==> $factory->codegenEnumMember($val));
+				$enum_obj = $factory->codegenEnum('enum', 'string')->addMembers($members);
+        $this->codegenProperty('enum')->setType('enum')->setPublic()->setValue($enum_obj->getCode(), HackBuilderValues::literal());
+			} else {
+				$hb = $this->getHackBuilder()
+					->addValue($enum, HackBuilderValues::vec(HackBuilderValues::export()));
 
-      $property = $this->codegenProperty('enum')
-        ->setType('vec<mixed>')
-        ->setValue($hb->getCode(), HackBuilderValues::literal());
-    }
-    return $property;
-  }
+				$property = $this->codegenProperty('enum')
+					->setType('vec<mixed>')
+					->setValue($hb->getCode(), HackBuilderValues::literal());
+			}
+		}
+		return $property;
+	}
 
-  protected function addEnumConstraintCheck(HackBuilder $hb): void {
-    $schema = type_assert_shape($this->typed_schema, 'Slack\Hack\JsonSchema\Codegen\TSchema');
-    if (($schema['enum'] ?? null) is nonnull) {
-      $hb->addMultilineCall('Constraints\EnumConstraint::check', vec['$typed', 'self::$enum', '$pointer']);
-    }
-  }
+	protected function addEnumConstraintCheck(HackBuilder $hb): void {
+		$schema = type_assert_shape($this->typed_schema, 'Slack\Hack\JsonSchema\Codegen\TSchema');
+		if (($schema['enum'] ?? null) is nonnull) {
+			$hb->addMultilineCall('Constraints\EnumConstraint::check', vec['$typed', 'self::$enum', '$pointer']);
+		}
+	}
 
-  protected function addHackEnumConstraintCheck(HackBuilder $hb): void {
-    $schema = type_assert_type($this->typed_schema, TSchema::class);
-    if (!Shapes::keyExists($schema, 'hackEnum')) {
-      return;
-    }
+	protected function addHackEnumConstraintCheck(HackBuilder $hb): void {
+		$schema = type_assert_type($this->typed_schema, TSchema::class);
+		if (!Shapes::keyExists($schema, 'hackEnum')) {
+			return;
+		}
 
-    try {
-      $rc = new \ReflectionClass($schema['hackEnum']);
-    } catch (\ReflectionException $e) {
-      throw new \Exception(Str\format("Hack enum '%s' does not exist", $schema['hackEnum']));
-    }
+		try {
+			$rc = new \ReflectionClass($schema['hackEnum']);
+		} catch (\ReflectionException $e) {
+			throw new \Exception(Str\format("Hack enum '%s' does not exist", $schema['hackEnum']));
+		}
 
-    invariant($rc->isEnum(), "'%s' is not an enum", $schema['hackEnum']);
+		invariant($rc->isEnum(), "'%s' is not an enum", $schema['hackEnum']);
 
-    $schema_type = $schema['type'] ?? null;
-    $hack_enum_values = keyset[];
-    foreach ($rc->getConstants() as $hack_enum_value) {
-      if ($schema_type === TSchemaType::INTEGER_T) {
-        $hack_enum_value = $hack_enum_value ?as int;
-      } else {
-        $hack_enum_value = $hack_enum_value ?as string;
-      }
-      invariant(
-        $hack_enum_value is nonnull,
-        "'%s' must contain only values of type %s",
-        $rc->getName(),
-        $schema_type === TSchemaType::INTEGER_T ? 'int' : 'string',
-      );
-      $hack_enum_values[] = $hack_enum_value;
-    }
+		$schema_type = $schema['type'] ?? null;
+		$hack_enum_values = keyset[];
+		foreach ($rc->getConstants() as $hack_enum_value) {
+			if ($schema_type === TSchemaType::INTEGER_T) {
+				$hack_enum_value = $hack_enum_value ?as int;
+			} else {
+				$hack_enum_value = $hack_enum_value ?as string;
+			}
+			invariant(
+				$hack_enum_value is nonnull,
+				"'%s' must contain only values of type %s",
+				$rc->getName(),
+				$schema_type === TSchemaType::INTEGER_T ? 'int' : 'string',
+			);
+			$hack_enum_values[] = $hack_enum_value;
+		}
 
-    if (Shapes::keyExists($schema, 'enum')) {
-      // If both `enum` and `hackEnum` are specified, assert that `enum` is a subset of
-      // `hackEnum` values. Any value not also in `hackEnum` can't be valid.
-      foreach ($schema['enum'] as $enum_value) {
-        invariant(
-          $enum_value is string,
-          "Enum value '%s' is not a valid value for '%s'",
-          \print_r($enum_value, true),
-          $rc->getName(),
-        );
-        invariant(
-          C\contains_key($hack_enum_values, $enum_value),
-          "Enum value '%s' is unexpectedly not present in '%s'",
-          \print_r($enum_value, true),
-          $rc->getName(),
-        );
-      }
-    }
+		if (Shapes::keyExists($schema, 'enum')) {
+			// If both `enum` and `hackEnum` are specified, assert that `enum` is a subset of
+			// `hackEnum` values. Any value not also in `hackEnum` can't be valid.
+			foreach ($schema['enum'] as $enum_value) {
+				invariant(
+					$enum_value is string,
+					"Enum value '%s' is not a valid value for '%s'",
+					\print_r($enum_value, true),
+					$rc->getName(),
+				);
+				invariant(
+					C\contains_key($hack_enum_values, $enum_value),
+					"Enum value '%s' is unexpectedly not present in '%s'",
+					\print_r($enum_value, true),
+					$rc->getName(),
+				);
+			}
+		}
 
-    $hb->addMultilineCall(
-      '$typed = Constraints\HackEnumConstraint::check',
-      vec[
-        '$typed',
-        Str\format('\%s::class', $rc->getName()),
-        '$pointer',
-      ],
-    );
-  }
+		$hb->addMultilineCall(
+			'$typed = Constraints\HackEnumConstraint::check',
+			vec[
+				'$typed',
+				Str\format('\%s::class', $rc->getName()),
+				'$pointer',
+			],
+		);
+	}
 
-  public function addBuilderClass(CodegenClass $class): void {
-    if ($this->class) {
-      return;
-    }
+	public function addBuilderClass(CodegenClass $class): void {
+		if ($this->class) {
+			return;
+		}
 
-    $this->ctx->getFile()->addClass($class);
-  }
+		$this->ctx->getFile()->addClass($class);
+	}
 
-  public function setSuffix(string $suffix): void {
-    $this->suffix = $suffix;
-  }
+	public function setSuffix(string $suffix): void {
+		$this->suffix = $suffix;
+	}
 }

--- a/src/Codegen/Constraints/BaseBuilder.php
+++ b/src/Codegen/Constraints/BaseBuilder.php
@@ -7,177 +7,177 @@ use type Facebook\HackCodegen\{CodegenClass, CodegenMethod, CodegenProperty, Hac
 
 <<__ConsistentConstruct>>
 abstract class BaseBuilder<T> implements IBuilder {
-	use Factory;
+  use Factory;
 
-	protected T $typed_schema;
-	protected static string $schema_name = '';
+  protected T $typed_schema;
+  protected static string $schema_name = '';
 
-	public function __construct(
-		protected Context $ctx,
-		protected string $suffix,
-		protected TSchema $schema,
-		protected ?CodegenClass $class = null,
-	) {
-		$this->typed_schema = type_assert_shape($this->schema, static::$schema_name);
-	}
+  public function __construct(
+    protected Context $ctx,
+    protected string $suffix,
+    protected TSchema $schema,
+    protected ?CodegenClass $class = null,
+  ) {
+    $this->typed_schema = type_assert_shape($this->schema, static::$schema_name);
+  }
 
-	/**
-	*
-	* Return a string which will get rendered as a literal value describing the
-	* output type of the schema. For example, the `StringBuilder` would return:
-	* `return 'string';`, the `NumberBuilder` would return: `return 'num';`.
-	*/
-	abstract public function getType(): string;
+  /**
+  *
+  * Return a string which will get rendered as a literal value describing the
+  * output type of the schema. For example, the `StringBuilder` would return:
+  * `return 'string';`, the `NumberBuilder` would return: `return 'num';`.
+  */
+  abstract public function getType(): string;
 
-	public function isArrayKeyType(): bool {
-		$type = $this->getType();
-		if ($type === 'string' || $type === 'int') {
-			return true;
-		}
+  public function isArrayKeyType(): bool {
+    $type = $this->getType();
+    if ($type === 'string' || $type === 'int') {
+      return true;
+    }
 
-		$schema = type_assert_type($this->typed_schema, TSchema::class);
-		return Shapes::keyExists($schema, 'hackEnum');
-	}
+    $schema = type_assert_type($this->typed_schema, TSchema::class);
+    return Shapes::keyExists($schema, 'hackEnum');
+  }
 
-	/**
-	*
-	* Main method for building the class for the schema and appending it to the
-	* file.
-	*/
-	abstract public function build(): this;
+  /**
+  *
+  * Main method for building the class for the schema and appending it to the
+  * file.
+  */
+  abstract public function build(): this;
 
-	protected function getHackBuilder(): HackBuilder {
-		return new HackBuilder($this->ctx->getHackCodegenFactory()->getConfig());
-	}
+  protected function getHackBuilder(): HackBuilder {
+    return new HackBuilder($this->ctx->getHackCodegenFactory()->getConfig());
+  }
 
-	public function getClassName(): string {
-		return $this->generateClassName($this->ctx->getClassName(), $this->suffix);
-	}
+  public function getClassName(): string {
+    return $this->generateClassName($this->ctx->getClassName(), $this->suffix);
+  }
 
-	protected function codegenClass(): CodegenClass {
-		if ($this->class) {
-			return $this->class;
-		}
+  protected function codegenClass(): CodegenClass {
+    if ($this->class) {
+      return $this->class;
+    }
 
-		return $this->ctx
-			->getHackCodegenFactory()
-			->codegenClass($this->getClassName())
-			->setIsFinal(true);
-	}
+    return $this->ctx
+      ->getHackCodegenFactory()
+      ->codegenClass($this->getClassName())
+      ->setIsFinal(true);
+  }
 
-	protected function codegenProperty(string $name): CodegenProperty {
-		return $this->ctx
-			->getHackCodegenFactory()
-			->codegenProperty($name)
-			->setIsStatic(true)
-			->setPrivate();
-	}
+  protected function codegenProperty(string $name): CodegenProperty {
+    return $this->ctx
+      ->getHackCodegenFactory()
+      ->codegenProperty($name)
+      ->setIsStatic(true)
+      ->setPrivate();
+  }
 
-	protected function codegenCheckMethod(): CodegenMethod {
-		return $this->ctx
-			->getHackCodegenFactory()
-			->codegenMethod('check')
-			->setPublic()
-			->setIsStatic(true);
-	}
+  protected function codegenCheckMethod(): CodegenMethod {
+    return $this->ctx
+      ->getHackCodegenFactory()
+      ->codegenMethod('check')
+      ->setPublic()
+      ->setIsStatic(true);
+  }
 
-	protected function getEnumCodegenProperty(): ?CodegenProperty {
-		$property = null;
-		$schema = type_assert_shape($this->typed_schema, 'Slack\Hack\JsonSchema\Codegen\TSchema');
-		$enum = $schema['enum'] ?? null;
-		if ($enum is nonnull) {
-			$hb = $this->getHackBuilder()
-				->addValue($enum, HackBuilderValues::vec(HackBuilderValues::export()));
+  protected function getEnumCodegenProperty(): ?CodegenProperty {
+    $property = null;
+    $schema = type_assert_shape($this->typed_schema, 'Slack\Hack\JsonSchema\Codegen\TSchema');
+    $enum = $schema['enum'] ?? null;
+    if ($enum is nonnull) {
+      $hb = $this->getHackBuilder()
+        ->addValue($enum, HackBuilderValues::vec(HackBuilderValues::export()));
 
-			$property = $this->codegenProperty('enum')
-				->setType('vec<mixed>')
-				->setValue($hb->getCode(), HackBuilderValues::literal());
-		}
-		return $property;
-	}
+      $property = $this->codegenProperty('enum')
+        ->setType('vec<mixed>')
+        ->setValue($hb->getCode(), HackBuilderValues::literal());
+    }
+    return $property;
+  }
 
-	protected function addEnumConstraintCheck(HackBuilder $hb): void {
-		$schema = type_assert_shape($this->typed_schema, 'Slack\Hack\JsonSchema\Codegen\TSchema');
-		if (($schema['enum'] ?? null) is nonnull) {
-			$hb->addMultilineCall('Constraints\EnumConstraint::check', vec['$typed', 'self::$enum', '$pointer']);
-		}
-	}
+  protected function addEnumConstraintCheck(HackBuilder $hb): void {
+    $schema = type_assert_shape($this->typed_schema, 'Slack\Hack\JsonSchema\Codegen\TSchema');
+    if (($schema['enum'] ?? null) is nonnull) {
+      $hb->addMultilineCall('Constraints\EnumConstraint::check', vec['$typed', 'self::$enum', '$pointer']);
+    }
+  }
 
-	protected function addHackEnumConstraintCheck(HackBuilder $hb): void {
-		$schema = type_assert_type($this->typed_schema, TSchema::class);
-		if (!Shapes::keyExists($schema, 'hackEnum')) {
-			return;
-		}
-		$generateHackEnum = $schema['generateHackEnum'] ?? false;
-		if (!$generateHackEnum) {
+  protected function addHackEnumConstraintCheck(HackBuilder $hb): void {
+    $schema = type_assert_type($this->typed_schema, TSchema::class);
+    if (!Shapes::keyExists($schema, 'hackEnum')) {
+      return;
+    }
+    $generateHackEnum = $schema['generateHackEnum'] ?? false;
+    if (!$generateHackEnum) {
 
-			try {
-				$rc = new \ReflectionClass($schema['hackEnum']);
-			} catch (\ReflectionException $e) {
-				throw new \Exception(Str\format("Hack enum '%s' does not exist", $schema['hackEnum']));
-			}
+      try {
+        $rc = new \ReflectionClass($schema['hackEnum']);
+      } catch (\ReflectionException $e) {
+        throw new \Exception(Str\format("Hack enum '%s' does not exist", $schema['hackEnum']));
+      }
 
-			invariant($rc->isEnum(), "'%s' is not an enum", $schema['hackEnum']);
+      invariant($rc->isEnum(), "'%s' is not an enum", $schema['hackEnum']);
 
-			$schema_type = $schema['type'] ?? null;
-			$hack_enum_values = keyset[];
-			foreach ($rc->getConstants() as $hack_enum_value) {
-				if ($schema_type === TSchemaType::INTEGER_T) {
-					$hack_enum_value = $hack_enum_value ?as int;
-				} else {
-					$hack_enum_value = $hack_enum_value ?as string;
-				}
-				invariant(
-					$hack_enum_value is nonnull,
-					"'%s' must contain only values of type %s",
-					$rc->getName(),
-					$schema_type === TSchemaType::INTEGER_T ? 'int' : 'string',
-				);
-				$hack_enum_values[] = $hack_enum_value;
-			}
+      $schema_type = $schema['type'] ?? null;
+      $hack_enum_values = keyset[];
+      foreach ($rc->getConstants() as $hack_enum_value) {
+        if ($schema_type === TSchemaType::INTEGER_T) {
+          $hack_enum_value = $hack_enum_value ?as int;
+        } else {
+          $hack_enum_value = $hack_enum_value ?as string;
+        }
+        invariant(
+          $hack_enum_value is nonnull,
+          "'%s' must contain only values of type %s",
+          $rc->getName(),
+          $schema_type === TSchemaType::INTEGER_T ? 'int' : 'string',
+        );
+        $hack_enum_values[] = $hack_enum_value;
+      }
 
-			if (Shapes::keyExists($schema, 'enum')) {
-				// If both `enum` and `hackEnum` are specified, assert that `enum` is a subset of
-				// `hackEnum` values. Any value not also in `hackEnum` can't be valid.
-				foreach ($schema['enum'] as $enum_value) {
-					invariant(
-						$enum_value is string,
-						"Enum value '%s' is not a valid value for '%s'",
-						\print_r($enum_value, true),
-						$rc->getName(),
-					);
-					invariant(
-						C\contains_key($hack_enum_values, $enum_value),
-						"Enum value '%s' is unexpectedly not present in '%s'",
-						\print_r($enum_value, true),
-						$rc->getName(),
-					);
-				}
-			}
-			$enum_name = Str\format('\%s::class', $rc->getName());
-		} else {
-			$enum_name = $schema['hackEnum'].'::class';
-		}
+      if (Shapes::keyExists($schema, 'enum')) {
+        // If both `enum` and `hackEnum` are specified, assert that `enum` is a subset of
+        // `hackEnum` values. Any value not also in `hackEnum` can't be valid.
+        foreach ($schema['enum'] as $enum_value) {
+          invariant(
+            $enum_value is string,
+            "Enum value '%s' is not a valid value for '%s'",
+            \print_r($enum_value, true),
+            $rc->getName(),
+          );
+          invariant(
+            C\contains_key($hack_enum_values, $enum_value),
+            "Enum value '%s' is unexpectedly not present in '%s'",
+            \print_r($enum_value, true),
+            $rc->getName(),
+          );
+        }
+      }
+      $enum_name = Str\format('\%s::class', $rc->getName());
+    } else {
+      $enum_name = $schema['hackEnum'].'::class';
+    }
 
-		$hb->addMultilineCall(
-			'$typed = Constraints\HackEnumConstraint::check',
-			vec[
-				'$typed',
-				$enum_name,
-				'$pointer',
-			],
-		);
-	}
+    $hb->addMultilineCall(
+      '$typed = Constraints\HackEnumConstraint::check',
+      vec[
+        '$typed',
+        $enum_name,
+        '$pointer',
+      ],
+    );
+  }
 
-	public function addBuilderClass(CodegenClass $class): void {
-		if ($this->class) {
-			return;
-		}
+  public function addBuilderClass(CodegenClass $class): void {
+    if ($this->class) {
+      return;
+    }
 
-		$this->ctx->getFile()->addClass($class);
-	}
+    $this->ctx->getFile()->addClass($class);
+  }
 
-	public function setSuffix(string $suffix): void {
-		$this->suffix = $suffix;
-	}
+  public function setSuffix(string $suffix): void {
+    $this->suffix = $suffix;
+  }
 }

--- a/src/Codegen/Constraints/BaseBuilder.php
+++ b/src/Codegen/Constraints/BaseBuilder.php
@@ -154,16 +154,16 @@ abstract class BaseBuilder<T> implements IBuilder {
 					);
 				}
 			}
-			$enum_name = $rc->getName();
+			$enum_name = Str\format('\%s::class', $rc->getName());
 		} else {
-			$enum_name = $schema['hackEnum'];
+			$enum_name = $schema['hackEnum'].'::class';
 		}
 
 		$hb->addMultilineCall(
 			'$typed = Constraints\HackEnumConstraint::check',
 			vec[
 				'$typed',
-				Str\format('\%s::class', $enum_name),
+				$enum_name,
 				'$pointer',
 			],
 		);

--- a/src/Codegen/Constraints/StringBuilder.php
+++ b/src/Codegen/Constraints/StringBuilder.php
@@ -7,182 +7,182 @@ use namespace HH\Lib\Str;
 use type Facebook\HackCodegen\{CodegenMethod, HackBuilderValues};
 
 type TStringSchema = shape(
-	'type' => TSchemaType,
-	?'maxLength' => int,
-	?'minLength' => int,
-	?'enum' => vec<string>,
-	?'hackEnum' => string,
-	?'generateHackEnum' => bool,
-	?'pattern' => string,
-	?'format' => string,
-	?'sanitize' => shape(
-		'multiline' => bool,
-	),
-	?'coerce' => bool,
-	...
+  'type' => TSchemaType,
+  ?'maxLength' => int,
+  ?'minLength' => int,
+  ?'enum' => vec<string>,
+  ?'hackEnum' => string,
+  ?'generateHackEnum' => bool,
+  ?'pattern' => string,
+  ?'format' => string,
+  ?'sanitize' => shape(
+    'multiline' => bool,
+  ),
+  ?'coerce' => bool,
+  ...
 );
 
 class StringBuilder extends BaseBuilder<TStringSchema> {
-	protected static string $schema_name = 'Slack\Hack\JsonSchema\Codegen\TStringSchema';
+  protected static string $schema_name = 'Slack\Hack\JsonSchema\Codegen\TStringSchema';
 
-	<<__Override>>
-	public function build(): this {
-		$class = $this->codegenClass()
-			->addMethod($this->getCheckMethod());
+  <<__Override>>
+  public function build(): this {
+    $class = $this->codegenClass()
+      ->addMethod($this->getCheckMethod());
 
-		$properties = vec[];
-		$max_length = $this->typed_schema['maxLength'] ?? null;
-		if ($max_length is nonnull) {
-			$properties[] = $this->codegenProperty('maxLength')
-				->setType('int')
-				->setValue($max_length, HackBuilderValues::export());
-		}
+    $properties = vec[];
+    $max_length = $this->typed_schema['maxLength'] ?? null;
+    if ($max_length is nonnull) {
+      $properties[] = $this->codegenProperty('maxLength')
+        ->setType('int')
+        ->setValue($max_length, HackBuilderValues::export());
+    }
 
-		$min_length = $this->typed_schema['minLength'] ?? null;
-		if ($min_length is nonnull) {
-			$properties[] = $this->codegenProperty('minLength')
-				->setType('int')
-				->setValue($min_length, HackBuilderValues::export());
-		}
+    $min_length = $this->typed_schema['minLength'] ?? null;
+    if ($min_length is nonnull) {
+      $properties[] = $this->codegenProperty('minLength')
+        ->setType('int')
+        ->setValue($min_length, HackBuilderValues::export());
+    }
 
-		$pattern = $this->typed_schema['pattern'] ?? null;
-		if ($pattern is nonnull) {
-			$properties[] = $this->codegenProperty('pattern')
-				->setType('string')
-				->setValue($pattern, HackBuilderValues::export());
-		}
+    $pattern = $this->typed_schema['pattern'] ?? null;
+    if ($pattern is nonnull) {
+      $properties[] = $this->codegenProperty('pattern')
+        ->setType('string')
+        ->setValue($pattern, HackBuilderValues::export());
+    }
 
-		$format = $this->typed_schema['format'] ?? null;
-		if ($format is nonnull) {
-			$properties[] = $this->codegenProperty('format')
-				->setType('string')
-				->setValue($format, HackBuilderValues::export());
-		}
+    $format = $this->typed_schema['format'] ?? null;
+    if ($format is nonnull) {
+      $properties[] = $this->codegenProperty('format')
+        ->setType('string')
+        ->setValue($format, HackBuilderValues::export());
+    }
 
-		$enum = $this->getEnumCodegenProperty();
-		$generateHackEnum = $this->typed_schema['generateHackEnum'] ?? false;
-		if ($enum is nonnull) {
-			if ($generateHackEnum) {
-				$enum = $this->typed_schema['enum'] ?? vec[];
-				$factory = $this->ctx->getHackCodegenFactory();
-				$members = \HH\Lib\Vec\map(
-					$enum,
-					$member ==> $factory->codegenEnumMember(Str\uppercase($member))
-						->setValue($member, HackBuilderValues::export()),
-				);
-				$enumName = $this->typed_schema['hackEnum'] ?? null;
-				invariant($enumName is string, 'hackEnum is required when generating hack enum.');
-				invariant(!Str\contains($enumName, '\\'), 'hackEnum must not contain a slash.');
-				$enum_obj = $factory->codegenEnum($enumName, 'string')
-					->addMembers($members)
-					->setIsAs('string');
-				$this->ctx->getFile()->addEnum($enum_obj);
-			} else {
-				$properties[] = $enum;
-			}
-		} else {
-			invariant(!$generateHackEnum, 'enum is required when generating hack enum');
-		}
+    $enum = $this->getEnumCodegenProperty();
+    $generateHackEnum = $this->typed_schema['generateHackEnum'] ?? false;
+    if ($enum is nonnull) {
+      if ($generateHackEnum) {
+        $enum = $this->typed_schema['enum'] ?? vec[];
+        $factory = $this->ctx->getHackCodegenFactory();
+        $members = \HH\Lib\Vec\map(
+          $enum,
+          $member ==> $factory->codegenEnumMember(Str\uppercase($member))
+            ->setValue($member, HackBuilderValues::export()),
+        );
+        $enumName = $this->typed_schema['hackEnum'] ?? null;
+        invariant($enumName is string, 'hackEnum is required when generating hack enum.');
+        invariant(!Str\contains($enumName, '\\'), 'hackEnum must not contain a slash.');
+        $enum_obj = $factory->codegenEnum($enumName, 'string')
+          ->addMembers($members)
+          ->setIsAs('string');
+        $this->ctx->getFile()->addEnum($enum_obj);
+      } else {
+        $properties[] = $enum;
+      }
+    } else {
+      invariant(!$generateHackEnum, 'enum is required when generating hack enum');
+    }
 
-		$coerce = $this->typed_schema['coerce'] ?? $this->ctx->getCoerceDefault();
-		$properties[] = $this->codegenProperty('coerce')
-			->setType('bool')
-			->setValue($coerce, HackBuilderValues::export());
+    $coerce = $this->typed_schema['coerce'] ?? $this->ctx->getCoerceDefault();
+    $properties[] = $this->codegenProperty('coerce')
+      ->setType('bool')
+      ->setValue($coerce, HackBuilderValues::export());
 
-		$class->addProperties($properties);
-		$this->addBuilderClass($class);
+    $class->addProperties($properties);
+    $this->addBuilderClass($class);
 
-		return $this;
-	}
+    return $this;
+  }
 
-	protected function getCheckMethod(): CodegenMethod {
-		$hb = $this->getHackBuilder()
-			->addAssignment(
-				'$typed',
-				'Constraints\StringConstraint::check($input, $pointer, self::$coerce)',
-				HackBuilderValues::literal(),
-			)
-			->ensureEmptyLine();
+  protected function getCheckMethod(): CodegenMethod {
+    $hb = $this->getHackBuilder()
+      ->addAssignment(
+        '$typed',
+        'Constraints\StringConstraint::check($input, $pointer, self::$coerce)',
+        HackBuilderValues::literal(),
+      )
+      ->ensureEmptyLine();
 
-		$sanitize = $this->typed_schema['sanitize'] ?? null;
-		$sanitize_string = $this->ctx->getSanitizeStringConfig();
-		if ($sanitize is nonnull && $sanitize_string === null) {
-			throw new \Exception('Specified `sanitize` on a string without providing sanitization functions.');
-		} else if ($sanitize is nonnull && $sanitize_string is nonnull) {
-			if ($sanitize['multiline']) {
-				$sanitization_func = get_function_name_from_function($sanitize_string['multiline']);
-			} else {
-				$sanitization_func = get_function_name_from_function($sanitize_string['uniline']);
-			}
+    $sanitize = $this->typed_schema['sanitize'] ?? null;
+    $sanitize_string = $this->ctx->getSanitizeStringConfig();
+    if ($sanitize is nonnull && $sanitize_string === null) {
+      throw new \Exception('Specified `sanitize` on a string without providing sanitization functions.');
+    } else if ($sanitize is nonnull && $sanitize_string is nonnull) {
+      if ($sanitize['multiline']) {
+        $sanitization_func = get_function_name_from_function($sanitize_string['multiline']);
+      } else {
+        $sanitization_func = get_function_name_from_function($sanitize_string['uniline']);
+      }
 
-			$hb
-				->addAssignment('$sanitize_string', "\\$sanitization_func<>", HackBuilderValues::literal())
-				->addAssignment('$typed', '$sanitize_string($typed)', HackBuilderValues::literal())
-				->ensureEmptyLine();
-		}
-		if (!($this->typed_schema['generateHackEnum'] ?? false)) {
-			$this->addEnumConstraintCheck($hb);
-		}
+      $hb
+        ->addAssignment('$sanitize_string', "\\$sanitization_func<>", HackBuilderValues::literal())
+        ->addAssignment('$typed', '$sanitize_string($typed)', HackBuilderValues::literal())
+        ->ensureEmptyLine();
+    }
+    if (!($this->typed_schema['generateHackEnum'] ?? false)) {
+      $this->addEnumConstraintCheck($hb);
+    }
 
-		$max_length = $this->typed_schema['maxLength'] ?? null;
-		$min_length = $this->typed_schema['minLength'] ?? null;
-		$pattern = $this->typed_schema['pattern'] ?? null;
-		$format = $this->typed_schema['format'] ?? null;
+    $max_length = $this->typed_schema['maxLength'] ?? null;
+    $min_length = $this->typed_schema['minLength'] ?? null;
+    $pattern = $this->typed_schema['pattern'] ?? null;
+    $format = $this->typed_schema['format'] ?? null;
 
-		if ($pattern is nonnull) {
-			$hb->addMultilineCall('Constraints\StringPatternConstraint::check', vec['$typed', 'self::$pattern', '$pointer']);
-		}
+    if ($pattern is nonnull) {
+      $hb->addMultilineCall('Constraints\StringPatternConstraint::check', vec['$typed', 'self::$pattern', '$pointer']);
+    }
 
-		if ($format is nonnull) {
-			$hb->addMultilineCall('Constraints\StringFormatConstraint::check', vec['$typed', 'self::$format', '$pointer']);
-		}
+    if ($format is nonnull) {
+      $hb->addMultilineCall('Constraints\StringFormatConstraint::check', vec['$typed', 'self::$format', '$pointer']);
+    }
 
-		if ($max_length is nonnull || $min_length is nonnull) {
-			$hb->addAssignment('$length', '\mb_strlen($typed)', HackBuilderValues::literal());
-		}
+    if ($max_length is nonnull || $min_length is nonnull) {
+      $hb->addAssignment('$length', '\mb_strlen($typed)', HackBuilderValues::literal());
+    }
 
-		if ($max_length is nonnull) {
-			$hb->addMultilineCall(
-				'Constraints\StringMaxLengthConstraint::check',
-				vec['$length', 'self::$maxLength', '$pointer'],
-			);
-		}
+    if ($max_length is nonnull) {
+      $hb->addMultilineCall(
+        'Constraints\StringMaxLengthConstraint::check',
+        vec['$length', 'self::$maxLength', '$pointer'],
+      );
+    }
 
-		if ($min_length is nonnull) {
-			$hb->addMultilineCall(
-				'Constraints\StringMinLengthConstraint::check',
-				vec['$length', 'self::$minLength', '$pointer'],
-			);
-		}
+    if ($min_length is nonnull) {
+      $hb->addMultilineCall(
+        'Constraints\StringMinLengthConstraint::check',
+        vec['$length', 'self::$minLength', '$pointer'],
+      );
+    }
 
-		$this->addHackEnumConstraintCheck($hb);
+    $this->addHackEnumConstraintCheck($hb);
 
-		$hb->addReturn('$typed', HackBuilderValues::literal());
+    $hb->addReturn('$typed', HackBuilderValues::literal());
 
-		return $this->codegenCheckMethod()
-			->addParameters(vec['mixed $input', 'string $pointer'])
-			->setBody($hb->getCode())
-			->setReturnType($this->getType());
-	}
+    return $this->codegenCheckMethod()
+      ->addParameters(vec['mixed $input', 'string $pointer'])
+      ->setBody($hb->getCode())
+      ->setReturnType($this->getType());
+  }
 
-	<<__Override>>
-	public function getType(): string {
-		if (Shapes::keyExists($this->typed_schema, 'hackEnum')) {
-			if ($this->typed_schema['generateHackEnum'] ?? false) {
-				return $this->typed_schema['hackEnum'];
-			}
-			return Str\format('\%s', $this->typed_schema['hackEnum']);
-		}
+  <<__Override>>
+  public function getType(): string {
+    if (Shapes::keyExists($this->typed_schema, 'hackEnum')) {
+      if ($this->typed_schema['generateHackEnum'] ?? false) {
+        return $this->typed_schema['hackEnum'];
+      }
+      return Str\format('\%s', $this->typed_schema['hackEnum']);
+    }
 
-		return 'string';
-	}
+    return 'string';
+  }
 
-	<<__Override>>
-	public function getTypeInfo(): Typing\Type {
-		if ($this->getType() === 'string') {
-			return Typing\TypeSystem::string();
-		}
-		// TODO: Type resolution for hackEnum
-		return Typing\TypeSystem::nonnull();
-	}
+  <<__Override>>
+  public function getTypeInfo(): Typing\Type {
+    if ($this->getType() === 'string') {
+      return Typing\TypeSystem::string();
+    }
+    // TODO: Type resolution for hackEnum
+    return Typing\TypeSystem::nonnull();
+  }
 }

--- a/src/Codegen/Constraints/StringBuilder.php
+++ b/src/Codegen/Constraints/StringBuilder.php
@@ -173,6 +173,9 @@ class StringBuilder extends BaseBuilder<TStringSchema> {
 	<<__Override>>
 	public function getType(): string {
 		if (Shapes::keyExists($this->typed_schema, 'hackEnum')) {
+			if ($this->typed_schema['generateHackEnum'] ?? false) {
+				return $this->typed_schema['hackEnum'];
+			}
 			return Str\format('\%s', $this->typed_schema['hackEnum']);
 		}
 

--- a/src/Codegen/Constraints/StringBuilder.php
+++ b/src/Codegen/Constraints/StringBuilder.php
@@ -7,187 +7,181 @@ use namespace HH\Lib\Str;
 use type Facebook\HackCodegen\{CodegenMethod, HackBuilderValues};
 
 type TStringSchema = shape(
-	'type' => TSchemaType,
-	?'maxLength' => int,
-	?'minLength' => int,
-	?'enum' => vec<string>,
-	?'hackEnum' => string,
-	?'generateHackEnum' => bool,
-	?'pattern' => string,
-	?'format' => string,
-	?'sanitize' => shape(
-		'multiline' => bool,
-	),
-	?'coerce' => bool,
-	...
+  'type' => TSchemaType,
+  ?'maxLength' => int,
+  ?'minLength' => int,
+  ?'enum' => vec<string>,
+  ?'hackEnum' => string,
+  ?'generateHackEnum' => bool,
+  ?'pattern' => string,
+  ?'format' => string,
+  ?'sanitize' => shape(
+    'multiline' => bool,
+  ),
+  ?'coerce' => bool,
+  ...
 );
 
 class StringBuilder extends BaseBuilder<TStringSchema> {
-	protected static string $schema_name = 'Slack\Hack\JsonSchema\Codegen\TStringSchema';
+  protected static string $schema_name = 'Slack\Hack\JsonSchema\Codegen\TStringSchema';
 
-	<<__Override>>
-	public function build(): this {
-		$class = $this->codegenClass()
-			->addMethod($this->getCheckMethod());
+  <<__Override>>
+  public function build(): this {
+    $class = $this->codegenClass()
+      ->addMethod($this->getCheckMethod());
 
-		$properties = vec[];
-		$max_length = $this->typed_schema['maxLength'] ?? null;
-		if ($max_length is nonnull) {
-			$properties[] = $this->codegenProperty('maxLength')
-				->setType('int')
-				->setValue($max_length, HackBuilderValues::export());
-		}
+    $properties = vec[];
+    $max_length = $this->typed_schema['maxLength'] ?? null;
+    if ($max_length is nonnull) {
+      $properties[] = $this->codegenProperty('maxLength')
+        ->setType('int')
+        ->setValue($max_length, HackBuilderValues::export());
+    }
 
-		$min_length = $this->typed_schema['minLength'] ?? null;
-		if ($min_length is nonnull) {
-			$properties[] = $this->codegenProperty('minLength')
-				->setType('int')
-				->setValue($min_length, HackBuilderValues::export());
-		}
+    $min_length = $this->typed_schema['minLength'] ?? null;
+    if ($min_length is nonnull) {
+      $properties[] = $this->codegenProperty('minLength')
+        ->setType('int')
+        ->setValue($min_length, HackBuilderValues::export());
+    }
 
-		$pattern = $this->typed_schema['pattern'] ?? null;
-		if ($pattern is nonnull) {
-			$properties[] = $this->codegenProperty('pattern')
-				->setType('string')
-				->setValue($pattern, HackBuilderValues::export());
-		}
+    $pattern = $this->typed_schema['pattern'] ?? null;
+    if ($pattern is nonnull) {
+      $properties[] = $this->codegenProperty('pattern')
+        ->setType('string')
+        ->setValue($pattern, HackBuilderValues::export());
+    }
 
-		$format = $this->typed_schema['format'] ?? null;
-		if ($format is nonnull) {
-			$properties[] = $this->codegenProperty('format')
-				->setType('string')
-				->setValue($format, HackBuilderValues::export());
-		}
+    $format = $this->typed_schema['format'] ?? null;
+    if ($format is nonnull) {
+      $properties[] = $this->codegenProperty('format')
+        ->setType('string')
+        ->setValue($format, HackBuilderValues::export());
+    }
 
-		$enum = $this->getEnumCodegenProperty();
-		$generateHackEnum = $this->typed_schema['generateHackEnum'] ?? false;
-		if ($enum is nonnull) {
-			if ($generateHackEnum) {
-				$enum = $this->typed_schema['enum'] ?? vec[];
-				$factory = $this->ctx->getHackCodegenFactory();
-				$members = \HH\Lib\Vec\map(
-					$enum,
-					$member ==> $factory->codegenEnumMember(Str\uppercase($member))
-						->setValue($member, HackBuilderValues::export()),
-				);
-				$enumName = $this->typed_schema['hackEnum'] ?? null;
-				invariant($enumName is string, 'hackEnum is required when generating hack enum.');
-				$enum_obj = $factory->codegenEnum($enumName, 'string')
-					->addMembers($members)
-					->setIsAs('string');
-				$this->ctx->getFile()->addEnum($enum_obj);
-			} else {
-				$properties[] = $enum;
-			}
-		} else {
-			invariant(!$generateHackEnum, 'enum is required when generating hack enum');
-		}
+    $enum = $this->getEnumCodegenProperty();
+    $generateHackEnum = $this->typed_schema['generateHackEnum'] ?? false;
+    if ($enum is nonnull) {
+      if ($generateHackEnum) {
+        $enum = $this->typed_schema['enum'] ?? vec[];
+        $factory = $this->ctx->getHackCodegenFactory();
+        $members = \HH\Lib\Vec\map(
+          $enum,
+          $member ==> $factory->codegenEnumMember(Str\uppercase($member))
+            ->setValue($member, HackBuilderValues::export()),
+        );
+        $enumName = $this->typed_schema['hackEnum'] ?? null;
+        invariant($enumName is string, 'hackEnum is required when generating hack enum.');
+        $enum_obj = $factory->codegenEnum($enumName, 'string')
+          ->addMembers($members)
+          ->setIsAs('string');
+        $this->ctx->getFile()->addEnum($enum_obj);
+      } else {
+        $properties[] = $enum;
+      }
+    } else {
+      invariant(!$generateHackEnum, 'enum is required when generating hack enum');
+    }
 
-		$coerce = $this->typed_schema['coerce'] ?? $this->ctx->getCoerceDefault();
-		$properties[] = $this->codegenProperty('coerce')
-			->setType('bool')
-			->setValue($coerce, HackBuilderValues::export());
+    $coerce = $this->typed_schema['coerce'] ?? $this->ctx->getCoerceDefault();
+    $properties[] = $this->codegenProperty('coerce')
+      ->setType('bool')
+      ->setValue($coerce, HackBuilderValues::export());
 
-		$class->addProperties($properties);
-		$this->addBuilderClass($class);
+    $class->addProperties($properties);
+    $this->addBuilderClass($class);
 
-		return $this;
-	}
+    return $this;
+  }
 
-	protected function getCheckMethod(): CodegenMethod {
-		$hb = $this->getHackBuilder()
-			->addAssignment(
-				'$typed',
-				'Constraints\StringConstraint::check($input, $pointer, self::$coerce)',
-				HackBuilderValues::literal(),
-			)
-			->ensureEmptyLine();
+  protected function getCheckMethod(): CodegenMethod {
+    $hb = $this->getHackBuilder()
+      ->addAssignment(
+        '$typed',
+        'Constraints\StringConstraint::check($input, $pointer, self::$coerce)',
+        HackBuilderValues::literal(),
+      )
+      ->ensureEmptyLine();
 
-		$sanitize = $this->typed_schema['sanitize'] ?? null;
-		$sanitize_string = $this->ctx->getSanitizeStringConfig();
-		if ($sanitize is nonnull && $sanitize_string === null) {
-			throw new \Exception('Specified `sanitize` on a string without providing sanitization functions.');
-		} else if ($sanitize is nonnull && $sanitize_string is nonnull) {
-			if ($sanitize['multiline']) {
-				$sanitization_func = get_function_name_from_function($sanitize_string['multiline']);
-			} else {
-				$sanitization_func = get_function_name_from_function($sanitize_string['uniline']);
-			}
+    $sanitize = $this->typed_schema['sanitize'] ?? null;
+    $sanitize_string = $this->ctx->getSanitizeStringConfig();
+    if ($sanitize is nonnull && $sanitize_string === null) {
+      throw new \Exception('Specified `sanitize` on a string without providing sanitization functions.');
+    } else if ($sanitize is nonnull && $sanitize_string is nonnull) {
+      if ($sanitize['multiline']) {
+        $sanitization_func = get_function_name_from_function($sanitize_string['multiline']);
+      } else {
+        $sanitization_func = get_function_name_from_function($sanitize_string['uniline']);
+      }
 
-			$hb
-				->addAssignment('$sanitize_string', "\\$sanitization_func<>", HackBuilderValues::literal())
-				->addAssignment('$typed', '$sanitize_string($typed)', HackBuilderValues::literal())
-				->ensureEmptyLine();
-		}
-		if (!($this->typed_schema['generateHackEnum'] ?? false)) {
-			$this->addEnumConstraintCheck($hb);
-		}
+      $hb
+        ->addAssignment('$sanitize_string', "\\$sanitization_func<>", HackBuilderValues::literal())
+        ->addAssignment('$typed', '$sanitize_string($typed)', HackBuilderValues::literal())
+        ->ensureEmptyLine();
+    }
+    if (!($this->typed_schema['generateHackEnum'] ?? false)) {
+      $this->addEnumConstraintCheck($hb);
+    }
 
-		$max_length = $this->typed_schema['maxLength'] ?? null;
-		$min_length = $this->typed_schema['minLength'] ?? null;
-		$pattern = $this->typed_schema['pattern'] ?? null;
-		$format = $this->typed_schema['format'] ?? null;
+    $max_length = $this->typed_schema['maxLength'] ?? null;
+    $min_length = $this->typed_schema['minLength'] ?? null;
+    $pattern = $this->typed_schema['pattern'] ?? null;
+    $format = $this->typed_schema['format'] ?? null;
 
-		if ($pattern is nonnull) {
-			$hb->addMultilineCall(
-				'Constraints\StringPatternConstraint::check',
-				vec['$typed', 'self::$pattern', '$pointer'],
-			);
-		}
+    if ($pattern is nonnull) {
+      $hb->addMultilineCall('Constraints\StringPatternConstraint::check', vec['$typed', 'self::$pattern', '$pointer']);
+    }
 
-		if ($format is nonnull) {
-			$hb->addMultilineCall(
-				'Constraints\StringFormatConstraint::check',
-				vec['$typed', 'self::$format', '$pointer'],
-			);
-		}
+    if ($format is nonnull) {
+      $hb->addMultilineCall('Constraints\StringFormatConstraint::check', vec['$typed', 'self::$format', '$pointer']);
+    }
 
-		if ($max_length is nonnull || $min_length is nonnull) {
-			$hb->addAssignment('$length', '\mb_strlen($typed)', HackBuilderValues::literal());
-		}
+    if ($max_length is nonnull || $min_length is nonnull) {
+      $hb->addAssignment('$length', '\mb_strlen($typed)', HackBuilderValues::literal());
+    }
 
-		if ($max_length is nonnull) {
-			$hb->addMultilineCall(
-				'Constraints\StringMaxLengthConstraint::check',
-				vec['$length', 'self::$maxLength', '$pointer'],
-			);
-		}
+    if ($max_length is nonnull) {
+      $hb->addMultilineCall(
+        'Constraints\StringMaxLengthConstraint::check',
+        vec['$length', 'self::$maxLength', '$pointer'],
+      );
+    }
 
-		if ($min_length is nonnull) {
-			$hb->addMultilineCall(
-				'Constraints\StringMinLengthConstraint::check',
-				vec['$length', 'self::$minLength', '$pointer'],
-			);
-		}
+    if ($min_length is nonnull) {
+      $hb->addMultilineCall(
+        'Constraints\StringMinLengthConstraint::check',
+        vec['$length', 'self::$minLength', '$pointer'],
+      );
+    }
 
-		$this->addHackEnumConstraintCheck($hb);
+    $this->addHackEnumConstraintCheck($hb);
 
-		$hb->addReturn('$typed', HackBuilderValues::literal());
+    $hb->addReturn('$typed', HackBuilderValues::literal());
 
-		return $this->codegenCheckMethod()
-			->addParameters(vec['mixed $input', 'string $pointer'])
-			->setBody($hb->getCode())
-			->setReturnType($this->getType());
-	}
+    return $this->codegenCheckMethod()
+      ->addParameters(vec['mixed $input', 'string $pointer'])
+      ->setBody($hb->getCode())
+      ->setReturnType($this->getType());
+  }
 
-	<<__Override>>
-	public function getType(): string {
-		if (Shapes::keyExists($this->typed_schema, 'hackEnum')) {
-			if ($this->typed_schema['generateHackEnum'] ?? false) {
-				return $this->typed_schema['hackEnum'];
-			}
-			return Str\format('\%s', $this->typed_schema['hackEnum']);
-		}
+  <<__Override>>
+  public function getType(): string {
+    if (Shapes::keyExists($this->typed_schema, 'hackEnum')) {
+      if ($this->typed_schema['generateHackEnum'] ?? false) {
+        return $this->typed_schema['hackEnum'];
+      }
+      return Str\format('\%s', $this->typed_schema['hackEnum']);
+    }
 
-		return 'string';
-	}
+    return 'string';
+  }
 
-	<<__Override>>
-	public function getTypeInfo(): Typing\Type {
-		if ($this->getType() === 'string') {
-			return Typing\TypeSystem::string();
-		}
-		// TODO: Type resolution for hackEnum
-		return Typing\TypeSystem::nonnull();
-	}
+  <<__Override>>
+  public function getTypeInfo(): Typing\Type {
+    if ($this->getType() === 'string') {
+      return Typing\TypeSystem::string();
+    }
+    // TODO: Type resolution for hackEnum
+    return Typing\TypeSystem::nonnull();
+  }
 }

--- a/src/Codegen/Constraints/StringBuilder.php
+++ b/src/Codegen/Constraints/StringBuilder.php
@@ -117,9 +117,7 @@ class StringBuilder extends BaseBuilder<TStringSchema> {
 				->addAssignment('$typed', '$sanitize_string($typed)', HackBuilderValues::literal())
 				->ensureEmptyLine();
 		}
-		if ($this->typed_schema['generateHackEnum'] ?? false) {
-			$this->addHackEnumConstraintCheck($hb);
-		} else {
+		if (!($this->typed_schema['generateHackEnum'] ?? false)) {
 			$this->addEnumConstraintCheck($hb);
 		}
 

--- a/src/Codegen/Constraints/StringBuilder.php
+++ b/src/Codegen/Constraints/StringBuilder.php
@@ -60,12 +60,12 @@ class StringBuilder extends BaseBuilder<TStringSchema> {
 		}
 
 		$enum = $this->getEnumCodegenProperty();
+		$generateHackEnum = $this->typed_schema['generateHackEnum'] ?? false;
 		if ($enum is nonnull) {
-			$generateHackEnum = $this->typed_schema['generateHackEnum'] ?? false;
 			if ($generateHackEnum) {
 				$enum = $this->typed_schema['enum'] ?? vec[];
 				$factory = $this->ctx->getHackCodegenFactory();
-				$members = Vec\map(
+				$members = \HH\Lib\Vec\map(
 					$enum,
 					$member ==> $factory->codegenEnumMember(Str\uppercase($member))
 						->setValue($member, HackBuilderValues::export()),
@@ -79,6 +79,8 @@ class StringBuilder extends BaseBuilder<TStringSchema> {
 			} else {
 				$properties[] = $enum;
 			}
+		} else {
+			invariant(!$generateHackEnum, 'enum is required when generating hack enum');
 		}
 
 		$coerce = $this->typed_schema['coerce'] ?? $this->ctx->getCoerceDefault();

--- a/src/Codegen/Constraints/StringBuilder.php
+++ b/src/Codegen/Constraints/StringBuilder.php
@@ -7,157 +7,158 @@ use namespace HH\Lib\Str;
 use type Facebook\HackCodegen\{CodegenMethod, HackBuilderValues};
 
 type TStringSchema = shape(
-  'type' => TSchemaType,
-  ?'maxLength' => int,
-  ?'minLength' => int,
-  ?'enum' => vec<string>,
-  ?'hackEnum' => string,
-  ?'pattern' => string,
-  ?'format' => string,
-  ?'sanitize' => shape(
-    'multiline' => bool,
-  ),
-  ?'coerce' => bool,
-  ...
+	'type' => TSchemaType,
+	?'maxLength' => int,
+	?'minLength' => int,
+	?'enum' => vec<string>,
+	?'hackEnum' => string,
+	?'generateHackEnum' => bool,
+	?'pattern' => string,
+	?'format' => string,
+	?'sanitize' => shape(
+		'multiline' => bool,
+	),
+	?'coerce' => bool,
+	...
 );
 
 class StringBuilder extends BaseBuilder<TStringSchema> {
-  protected static string $schema_name = 'Slack\Hack\JsonSchema\Codegen\TStringSchema';
+	protected static string $schema_name = 'Slack\Hack\JsonSchema\Codegen\TStringSchema';
 
-  <<__Override>>
-  public function build(): this {
-    $class = $this->codegenClass()
-      ->addMethod($this->getCheckMethod());
+	<<__Override>>
+	public function build(): this {
+		$class = $this->codegenClass()
+			->addMethod($this->getCheckMethod());
 
-    $properties = vec[];
-    $max_length = $this->typed_schema['maxLength'] ?? null;
-    if ($max_length is nonnull) {
-      $properties[] = $this->codegenProperty('maxLength')
-        ->setType('int')
-        ->setValue($max_length, HackBuilderValues::export());
-    }
+		$properties = vec[];
+		$max_length = $this->typed_schema['maxLength'] ?? null;
+		if ($max_length is nonnull) {
+			$properties[] = $this->codegenProperty('maxLength')
+				->setType('int')
+				->setValue($max_length, HackBuilderValues::export());
+		}
 
-    $min_length = $this->typed_schema['minLength'] ?? null;
-    if ($min_length is nonnull) {
-      $properties[] = $this->codegenProperty('minLength')
-        ->setType('int')
-        ->setValue($min_length, HackBuilderValues::export());
-    }
+		$min_length = $this->typed_schema['minLength'] ?? null;
+		if ($min_length is nonnull) {
+			$properties[] = $this->codegenProperty('minLength')
+				->setType('int')
+				->setValue($min_length, HackBuilderValues::export());
+		}
 
-    $pattern = $this->typed_schema['pattern'] ?? null;
-    if ($pattern is nonnull) {
-      $properties[] = $this->codegenProperty('pattern')
-        ->setType('string')
-        ->setValue($pattern, HackBuilderValues::export());
-    }
+		$pattern = $this->typed_schema['pattern'] ?? null;
+		if ($pattern is nonnull) {
+			$properties[] = $this->codegenProperty('pattern')
+				->setType('string')
+				->setValue($pattern, HackBuilderValues::export());
+		}
 
-    $format = $this->typed_schema['format'] ?? null;
-    if ($format is nonnull) {
-      $properties[] = $this->codegenProperty('format')
-        ->setType('string')
-        ->setValue($format, HackBuilderValues::export());
-    }
+		$format = $this->typed_schema['format'] ?? null;
+		if ($format is nonnull) {
+			$properties[] = $this->codegenProperty('format')
+				->setType('string')
+				->setValue($format, HackBuilderValues::export());
+		}
 
-    $enum = $this->getEnumCodegenProperty();
-    if ($enum is nonnull) {
-      $properties[] = $enum;
-    }
+		$enum = $this->getEnumCodegenProperty();
+		if ($enum is nonnull) {
+			$properties[] = $enum;
+		}
 
-    $coerce = $this->typed_schema['coerce'] ?? $this->ctx->getCoerceDefault();
-    $properties[] = $this->codegenProperty('coerce')
-      ->setType('bool')
-      ->setValue($coerce, HackBuilderValues::export());
+		$coerce = $this->typed_schema['coerce'] ?? $this->ctx->getCoerceDefault();
+		$properties[] = $this->codegenProperty('coerce')
+			->setType('bool')
+			->setValue($coerce, HackBuilderValues::export());
 
-    $class->addProperties($properties);
-    $this->addBuilderClass($class);
+		$class->addProperties($properties);
+		$this->addBuilderClass($class);
 
-    return $this;
-  }
+		return $this;
+	}
 
-  protected function getCheckMethod(): CodegenMethod {
-    $hb = $this->getHackBuilder()
-      ->addAssignment(
-        '$typed',
-        'Constraints\StringConstraint::check($input, $pointer, self::$coerce)',
-        HackBuilderValues::literal(),
-      )
-      ->ensureEmptyLine();
+	protected function getCheckMethod(): CodegenMethod {
+		$hb = $this->getHackBuilder()
+			->addAssignment(
+				'$typed',
+				'Constraints\StringConstraint::check($input, $pointer, self::$coerce)',
+				HackBuilderValues::literal(),
+			)
+			->ensureEmptyLine();
 
-    $sanitize = $this->typed_schema['sanitize'] ?? null;
-    $sanitize_string = $this->ctx->getSanitizeStringConfig();
-    if ($sanitize is nonnull && $sanitize_string === null) {
-      throw new \Exception('Specified `sanitize` on a string without providing sanitization functions.');
-    } else if ($sanitize is nonnull && $sanitize_string is nonnull) {
-      if ($sanitize['multiline']) {
-        $sanitization_func = get_function_name_from_function($sanitize_string['multiline']);
-      } else {
-        $sanitization_func = get_function_name_from_function($sanitize_string['uniline']);
-      }
+		$sanitize = $this->typed_schema['sanitize'] ?? null;
+		$sanitize_string = $this->ctx->getSanitizeStringConfig();
+		if ($sanitize is nonnull && $sanitize_string === null) {
+			throw new \Exception('Specified `sanitize` on a string without providing sanitization functions.');
+		} else if ($sanitize is nonnull && $sanitize_string is nonnull) {
+			if ($sanitize['multiline']) {
+				$sanitization_func = get_function_name_from_function($sanitize_string['multiline']);
+			} else {
+				$sanitization_func = get_function_name_from_function($sanitize_string['uniline']);
+			}
 
-      $hb
-        ->addAssignment('$sanitize_string', "\\$sanitization_func<>", HackBuilderValues::literal())
-        ->addAssignment('$typed', '$sanitize_string($typed)', HackBuilderValues::literal())
-        ->ensureEmptyLine();
-    }
+			$hb
+				->addAssignment('$sanitize_string', "\\$sanitization_func<>", HackBuilderValues::literal())
+				->addAssignment('$typed', '$sanitize_string($typed)', HackBuilderValues::literal())
+				->ensureEmptyLine();
+		}
 
-    $this->addEnumConstraintCheck($hb);
+		$this->addEnumConstraintCheck($hb);
 
-    $max_length = $this->typed_schema['maxLength'] ?? null;
-    $min_length = $this->typed_schema['minLength'] ?? null;
-    $pattern = $this->typed_schema['pattern'] ?? null;
-    $format = $this->typed_schema['format'] ?? null;
+		$max_length = $this->typed_schema['maxLength'] ?? null;
+		$min_length = $this->typed_schema['minLength'] ?? null;
+		$pattern = $this->typed_schema['pattern'] ?? null;
+		$format = $this->typed_schema['format'] ?? null;
 
-    if ($pattern is nonnull) {
-      $hb->addMultilineCall('Constraints\StringPatternConstraint::check', vec['$typed', 'self::$pattern', '$pointer']);
-    }
+		if ($pattern is nonnull) {
+			$hb->addMultilineCall('Constraints\StringPatternConstraint::check', vec['$typed', 'self::$pattern', '$pointer']);
+		}
 
-    if ($format is nonnull) {
-      $hb->addMultilineCall('Constraints\StringFormatConstraint::check', vec['$typed', 'self::$format', '$pointer']);
-    }
+		if ($format is nonnull) {
+			$hb->addMultilineCall('Constraints\StringFormatConstraint::check', vec['$typed', 'self::$format', '$pointer']);
+		}
 
-    if ($max_length is nonnull || $min_length is nonnull) {
-      $hb->addAssignment('$length', '\mb_strlen($typed)', HackBuilderValues::literal());
-    }
+		if ($max_length is nonnull || $min_length is nonnull) {
+			$hb->addAssignment('$length', '\mb_strlen($typed)', HackBuilderValues::literal());
+		}
 
-    if ($max_length is nonnull) {
-      $hb->addMultilineCall(
-        'Constraints\StringMaxLengthConstraint::check',
-        vec['$length', 'self::$maxLength', '$pointer'],
-      );
-    }
+		if ($max_length is nonnull) {
+			$hb->addMultilineCall(
+				'Constraints\StringMaxLengthConstraint::check',
+				vec['$length', 'self::$maxLength', '$pointer'],
+			);
+		}
 
-    if ($min_length is nonnull) {
-      $hb->addMultilineCall(
-        'Constraints\StringMinLengthConstraint::check',
-        vec['$length', 'self::$minLength', '$pointer'],
-      );
-    }
+		if ($min_length is nonnull) {
+			$hb->addMultilineCall(
+				'Constraints\StringMinLengthConstraint::check',
+				vec['$length', 'self::$minLength', '$pointer'],
+			);
+		}
 
-    $this->addHackEnumConstraintCheck($hb);
+		$this->addHackEnumConstraintCheck($hb);
 
-    $hb->addReturn('$typed', HackBuilderValues::literal());
+		$hb->addReturn('$typed', HackBuilderValues::literal());
 
-    return $this->codegenCheckMethod()
-      ->addParameters(vec['mixed $input', 'string $pointer'])
-      ->setBody($hb->getCode())
-      ->setReturnType($this->getType());
-  }
+		return $this->codegenCheckMethod()
+			->addParameters(vec['mixed $input', 'string $pointer'])
+			->setBody($hb->getCode())
+			->setReturnType($this->getType());
+	}
 
-  <<__Override>>
-  public function getType(): string {
-    if (Shapes::keyExists($this->typed_schema, 'hackEnum')) {
-      return Str\format('\%s', $this->typed_schema['hackEnum']);
-    }
+	<<__Override>>
+	public function getType(): string {
+		if (Shapes::keyExists($this->typed_schema, 'hackEnum')) {
+			return Str\format('\%s', $this->typed_schema['hackEnum']);
+		}
 
-    return 'string';
-  }
+		return 'string';
+	}
 
-  <<__Override>>
-  public function getTypeInfo(): Typing\Type {
-    if ($this->getType() === 'string') {
-      return Typing\TypeSystem::string();
-    }
-    // TODO: Type resolution for hackEnum
-    return Typing\TypeSystem::nonnull();
-  }
+	<<__Override>>
+	public function getTypeInfo(): Typing\Type {
+		if ($this->getType() === 'string') {
+			return Typing\TypeSystem::string();
+		}
+		// TODO: Type resolution for hackEnum
+		return Typing\TypeSystem::nonnull();
+	}
 }

--- a/src/Codegen/Constraints/StringBuilder.php
+++ b/src/Codegen/Constraints/StringBuilder.php
@@ -7,181 +7,182 @@ use namespace HH\Lib\Str;
 use type Facebook\HackCodegen\{CodegenMethod, HackBuilderValues};
 
 type TStringSchema = shape(
-  'type' => TSchemaType,
-  ?'maxLength' => int,
-  ?'minLength' => int,
-  ?'enum' => vec<string>,
-  ?'hackEnum' => string,
-  ?'generateHackEnum' => bool,
-  ?'pattern' => string,
-  ?'format' => string,
-  ?'sanitize' => shape(
-    'multiline' => bool,
-  ),
-  ?'coerce' => bool,
-  ...
+	'type' => TSchemaType,
+	?'maxLength' => int,
+	?'minLength' => int,
+	?'enum' => vec<string>,
+	?'hackEnum' => string,
+	?'generateHackEnum' => bool,
+	?'pattern' => string,
+	?'format' => string,
+	?'sanitize' => shape(
+		'multiline' => bool,
+	),
+	?'coerce' => bool,
+	...
 );
 
 class StringBuilder extends BaseBuilder<TStringSchema> {
-  protected static string $schema_name = 'Slack\Hack\JsonSchema\Codegen\TStringSchema';
+	protected static string $schema_name = 'Slack\Hack\JsonSchema\Codegen\TStringSchema';
 
-  <<__Override>>
-  public function build(): this {
-    $class = $this->codegenClass()
-      ->addMethod($this->getCheckMethod());
+	<<__Override>>
+	public function build(): this {
+		$class = $this->codegenClass()
+			->addMethod($this->getCheckMethod());
 
-    $properties = vec[];
-    $max_length = $this->typed_schema['maxLength'] ?? null;
-    if ($max_length is nonnull) {
-      $properties[] = $this->codegenProperty('maxLength')
-        ->setType('int')
-        ->setValue($max_length, HackBuilderValues::export());
-    }
+		$properties = vec[];
+		$max_length = $this->typed_schema['maxLength'] ?? null;
+		if ($max_length is nonnull) {
+			$properties[] = $this->codegenProperty('maxLength')
+				->setType('int')
+				->setValue($max_length, HackBuilderValues::export());
+		}
 
-    $min_length = $this->typed_schema['minLength'] ?? null;
-    if ($min_length is nonnull) {
-      $properties[] = $this->codegenProperty('minLength')
-        ->setType('int')
-        ->setValue($min_length, HackBuilderValues::export());
-    }
+		$min_length = $this->typed_schema['minLength'] ?? null;
+		if ($min_length is nonnull) {
+			$properties[] = $this->codegenProperty('minLength')
+				->setType('int')
+				->setValue($min_length, HackBuilderValues::export());
+		}
 
-    $pattern = $this->typed_schema['pattern'] ?? null;
-    if ($pattern is nonnull) {
-      $properties[] = $this->codegenProperty('pattern')
-        ->setType('string')
-        ->setValue($pattern, HackBuilderValues::export());
-    }
+		$pattern = $this->typed_schema['pattern'] ?? null;
+		if ($pattern is nonnull) {
+			$properties[] = $this->codegenProperty('pattern')
+				->setType('string')
+				->setValue($pattern, HackBuilderValues::export());
+		}
 
-    $format = $this->typed_schema['format'] ?? null;
-    if ($format is nonnull) {
-      $properties[] = $this->codegenProperty('format')
-        ->setType('string')
-        ->setValue($format, HackBuilderValues::export());
-    }
+		$format = $this->typed_schema['format'] ?? null;
+		if ($format is nonnull) {
+			$properties[] = $this->codegenProperty('format')
+				->setType('string')
+				->setValue($format, HackBuilderValues::export());
+		}
 
-    $enum = $this->getEnumCodegenProperty();
-    $generateHackEnum = $this->typed_schema['generateHackEnum'] ?? false;
-    if ($enum is nonnull) {
-      if ($generateHackEnum) {
-        $enum = $this->typed_schema['enum'] ?? vec[];
-        $factory = $this->ctx->getHackCodegenFactory();
-        $members = \HH\Lib\Vec\map(
-          $enum,
-          $member ==> $factory->codegenEnumMember(Str\uppercase($member))
-            ->setValue($member, HackBuilderValues::export()),
-        );
-        $enumName = $this->typed_schema['hackEnum'] ?? null;
-        invariant($enumName is string, 'hackEnum is required when generating hack enum.');
-        $enum_obj = $factory->codegenEnum($enumName, 'string')
-          ->addMembers($members)
-          ->setIsAs('string');
-        $this->ctx->getFile()->addEnum($enum_obj);
-      } else {
-        $properties[] = $enum;
-      }
-    } else {
-      invariant(!$generateHackEnum, 'enum is required when generating hack enum');
-    }
+		$enum = $this->getEnumCodegenProperty();
+		$generateHackEnum = $this->typed_schema['generateHackEnum'] ?? false;
+		if ($enum is nonnull) {
+			if ($generateHackEnum) {
+				$enum = $this->typed_schema['enum'] ?? vec[];
+				$factory = $this->ctx->getHackCodegenFactory();
+				$members = \HH\Lib\Vec\map(
+					$enum,
+					$member ==> $factory->codegenEnumMember(Str\uppercase($member))
+						->setValue($member, HackBuilderValues::export()),
+				);
+				$enumName = $this->typed_schema['hackEnum'] ?? null;
+				invariant($enumName is string, 'hackEnum is required when generating hack enum.');
+				invariant(!Str\contains($enumName, '\\'), 'hackEnum must not contain a slash.');
+				$enum_obj = $factory->codegenEnum($enumName, 'string')
+					->addMembers($members)
+					->setIsAs('string');
+				$this->ctx->getFile()->addEnum($enum_obj);
+			} else {
+				$properties[] = $enum;
+			}
+		} else {
+			invariant(!$generateHackEnum, 'enum is required when generating hack enum');
+		}
 
-    $coerce = $this->typed_schema['coerce'] ?? $this->ctx->getCoerceDefault();
-    $properties[] = $this->codegenProperty('coerce')
-      ->setType('bool')
-      ->setValue($coerce, HackBuilderValues::export());
+		$coerce = $this->typed_schema['coerce'] ?? $this->ctx->getCoerceDefault();
+		$properties[] = $this->codegenProperty('coerce')
+			->setType('bool')
+			->setValue($coerce, HackBuilderValues::export());
 
-    $class->addProperties($properties);
-    $this->addBuilderClass($class);
+		$class->addProperties($properties);
+		$this->addBuilderClass($class);
 
-    return $this;
-  }
+		return $this;
+	}
 
-  protected function getCheckMethod(): CodegenMethod {
-    $hb = $this->getHackBuilder()
-      ->addAssignment(
-        '$typed',
-        'Constraints\StringConstraint::check($input, $pointer, self::$coerce)',
-        HackBuilderValues::literal(),
-      )
-      ->ensureEmptyLine();
+	protected function getCheckMethod(): CodegenMethod {
+		$hb = $this->getHackBuilder()
+			->addAssignment(
+				'$typed',
+				'Constraints\StringConstraint::check($input, $pointer, self::$coerce)',
+				HackBuilderValues::literal(),
+			)
+			->ensureEmptyLine();
 
-    $sanitize = $this->typed_schema['sanitize'] ?? null;
-    $sanitize_string = $this->ctx->getSanitizeStringConfig();
-    if ($sanitize is nonnull && $sanitize_string === null) {
-      throw new \Exception('Specified `sanitize` on a string without providing sanitization functions.');
-    } else if ($sanitize is nonnull && $sanitize_string is nonnull) {
-      if ($sanitize['multiline']) {
-        $sanitization_func = get_function_name_from_function($sanitize_string['multiline']);
-      } else {
-        $sanitization_func = get_function_name_from_function($sanitize_string['uniline']);
-      }
+		$sanitize = $this->typed_schema['sanitize'] ?? null;
+		$sanitize_string = $this->ctx->getSanitizeStringConfig();
+		if ($sanitize is nonnull && $sanitize_string === null) {
+			throw new \Exception('Specified `sanitize` on a string without providing sanitization functions.');
+		} else if ($sanitize is nonnull && $sanitize_string is nonnull) {
+			if ($sanitize['multiline']) {
+				$sanitization_func = get_function_name_from_function($sanitize_string['multiline']);
+			} else {
+				$sanitization_func = get_function_name_from_function($sanitize_string['uniline']);
+			}
 
-      $hb
-        ->addAssignment('$sanitize_string', "\\$sanitization_func<>", HackBuilderValues::literal())
-        ->addAssignment('$typed', '$sanitize_string($typed)', HackBuilderValues::literal())
-        ->ensureEmptyLine();
-    }
-    if (!($this->typed_schema['generateHackEnum'] ?? false)) {
-      $this->addEnumConstraintCheck($hb);
-    }
+			$hb
+				->addAssignment('$sanitize_string', "\\$sanitization_func<>", HackBuilderValues::literal())
+				->addAssignment('$typed', '$sanitize_string($typed)', HackBuilderValues::literal())
+				->ensureEmptyLine();
+		}
+		if (!($this->typed_schema['generateHackEnum'] ?? false)) {
+			$this->addEnumConstraintCheck($hb);
+		}
 
-    $max_length = $this->typed_schema['maxLength'] ?? null;
-    $min_length = $this->typed_schema['minLength'] ?? null;
-    $pattern = $this->typed_schema['pattern'] ?? null;
-    $format = $this->typed_schema['format'] ?? null;
+		$max_length = $this->typed_schema['maxLength'] ?? null;
+		$min_length = $this->typed_schema['minLength'] ?? null;
+		$pattern = $this->typed_schema['pattern'] ?? null;
+		$format = $this->typed_schema['format'] ?? null;
 
-    if ($pattern is nonnull) {
-      $hb->addMultilineCall('Constraints\StringPatternConstraint::check', vec['$typed', 'self::$pattern', '$pointer']);
-    }
+		if ($pattern is nonnull) {
+			$hb->addMultilineCall('Constraints\StringPatternConstraint::check', vec['$typed', 'self::$pattern', '$pointer']);
+		}
 
-    if ($format is nonnull) {
-      $hb->addMultilineCall('Constraints\StringFormatConstraint::check', vec['$typed', 'self::$format', '$pointer']);
-    }
+		if ($format is nonnull) {
+			$hb->addMultilineCall('Constraints\StringFormatConstraint::check', vec['$typed', 'self::$format', '$pointer']);
+		}
 
-    if ($max_length is nonnull || $min_length is nonnull) {
-      $hb->addAssignment('$length', '\mb_strlen($typed)', HackBuilderValues::literal());
-    }
+		if ($max_length is nonnull || $min_length is nonnull) {
+			$hb->addAssignment('$length', '\mb_strlen($typed)', HackBuilderValues::literal());
+		}
 
-    if ($max_length is nonnull) {
-      $hb->addMultilineCall(
-        'Constraints\StringMaxLengthConstraint::check',
-        vec['$length', 'self::$maxLength', '$pointer'],
-      );
-    }
+		if ($max_length is nonnull) {
+			$hb->addMultilineCall(
+				'Constraints\StringMaxLengthConstraint::check',
+				vec['$length', 'self::$maxLength', '$pointer'],
+			);
+		}
 
-    if ($min_length is nonnull) {
-      $hb->addMultilineCall(
-        'Constraints\StringMinLengthConstraint::check',
-        vec['$length', 'self::$minLength', '$pointer'],
-      );
-    }
+		if ($min_length is nonnull) {
+			$hb->addMultilineCall(
+				'Constraints\StringMinLengthConstraint::check',
+				vec['$length', 'self::$minLength', '$pointer'],
+			);
+		}
 
-    $this->addHackEnumConstraintCheck($hb);
+		$this->addHackEnumConstraintCheck($hb);
 
-    $hb->addReturn('$typed', HackBuilderValues::literal());
+		$hb->addReturn('$typed', HackBuilderValues::literal());
 
-    return $this->codegenCheckMethod()
-      ->addParameters(vec['mixed $input', 'string $pointer'])
-      ->setBody($hb->getCode())
-      ->setReturnType($this->getType());
-  }
+		return $this->codegenCheckMethod()
+			->addParameters(vec['mixed $input', 'string $pointer'])
+			->setBody($hb->getCode())
+			->setReturnType($this->getType());
+	}
 
-  <<__Override>>
-  public function getType(): string {
-    if (Shapes::keyExists($this->typed_schema, 'hackEnum')) {
-      if ($this->typed_schema['generateHackEnum'] ?? false) {
-        return $this->typed_schema['hackEnum'];
-      }
-      return Str\format('\%s', $this->typed_schema['hackEnum']);
-    }
+	<<__Override>>
+	public function getType(): string {
+		if (Shapes::keyExists($this->typed_schema, 'hackEnum')) {
+			if ($this->typed_schema['generateHackEnum'] ?? false) {
+				return $this->typed_schema['hackEnum'];
+			}
+			return Str\format('\%s', $this->typed_schema['hackEnum']);
+		}
 
-    return 'string';
-  }
+		return 'string';
+	}
 
-  <<__Override>>
-  public function getTypeInfo(): Typing\Type {
-    if ($this->getType() === 'string') {
-      return Typing\TypeSystem::string();
-    }
-    // TODO: Type resolution for hackEnum
-    return Typing\TypeSystem::nonnull();
-  }
+	<<__Override>>
+	public function getTypeInfo(): Typing\Type {
+		if ($this->getType() === 'string') {
+			return Typing\TypeSystem::string();
+		}
+		// TODO: Type resolution for hackEnum
+		return Typing\TypeSystem::nonnull();
+	}
 }

--- a/tests/GeneratedHackEnumSchemaValidatorTest.php
+++ b/tests/GeneratedHackEnumSchemaValidatorTest.php
@@ -7,29 +7,29 @@ use type Slack\Hack\JsonSchema\Tests\Generated\GeneratedHackEnumSchemaValidator;
 
 final class GeneratedHackEnumSchemaValidatorTest extends BaseCodegenTestCase {
 
-	<<__Override>>
-	public static async function beforeFirstTestAsync(): Awaitable<void> {
-		$ret = self::getBuilder('generated-hack-enum-schema.json', 'GeneratedHackEnumSchemaValidator');
-		$ret['codegen']->build();
-		require_once($ret['path']);
-	}
-	public function testStringEnum(): void {
-		$cases = vec[
-			shape(
-				'input' => darray['enum_string' => 'one'],
-				'output' => darray['enum_string' => 'one'],
-				'valid' => true,
-			),
-			shape(
-				'input' => darray['enum_string' => 'four'],
-				'valid' => false,
-			),
-			shape(
-				'input' => darray['enum_string' => 1],
-				'valid' => false,
-			),
-		];
+  <<__Override>>
+  public static async function beforeFirstTestAsync(): Awaitable<void> {
+    $ret = self::getBuilder('generated-hack-enum-schema.json', 'GeneratedHackEnumSchemaValidator');
+    $ret['codegen']->build();
+    require_once($ret['path']);
+  }
+  public function testStringEnum(): void {
+    $cases = vec[
+      shape(
+        'input' => darray['enum_string' => 'one'],
+        'output' => darray['enum_string' => 'one'],
+        'valid' => true,
+      ),
+      shape(
+        'input' => darray['enum_string' => 'four'],
+        'valid' => false,
+      ),
+      shape(
+        'input' => darray['enum_string' => 1],
+        'valid' => false,
+      ),
+    ];
 
-		$this->expectCases($cases, $input ==> new GeneratedHackEnumSchemaValidator($input));
-	}
+    $this->expectCases($cases, $input ==> new GeneratedHackEnumSchemaValidator($input));
+  }
 }

--- a/tests/GeneratedHackEnumSchemaValidatorTest.php
+++ b/tests/GeneratedHackEnumSchemaValidatorTest.php
@@ -9,7 +9,7 @@ final class GeneratedHackEnumSchemaValidatorTest extends BaseCodegenTestCase {
 
 	<<__Override>>
 	public static async function beforeFirstTestAsync(): Awaitable<void> {
-		$ret = self::getBuilder('generated-hack-enum-schema.json', 'EnumSchemaValidator');
+		$ret = self::getBuilder('generated-hack-enum-schema.json', 'GeneratedHackEnumSchemaValidator');
 		$ret['codegen']->build();
 		require_once($ret['path']);
 	}

--- a/tests/GeneratedHackEnumSchemaValidatorTest.php
+++ b/tests/GeneratedHackEnumSchemaValidatorTest.php
@@ -1,0 +1,16 @@
+<?hh // strict
+
+namespace Slack\Hack\JsonSchema\Tests;
+
+
+use type Slack\Hack\JsonSchema\Tests\Generated\EnumSchemaValidator;
+
+final class GeneratedHackEnumSchemaValidatorTest extends BaseCodegenTestCase {
+
+	<<__Override>>
+	public static async function beforeFirstTestAsync(): Awaitable<void> {
+		$ret = self::getBuilder('generated-hack-enum-schema.json', 'EnumSchemaValidator');
+		$ret['codegen']->build();
+		require_once($ret['path']);
+	}
+}

--- a/tests/GeneratedHackEnumSchemaValidatorTest.php
+++ b/tests/GeneratedHackEnumSchemaValidatorTest.php
@@ -16,16 +16,16 @@ final class GeneratedHackEnumSchemaValidatorTest extends BaseCodegenTestCase {
   public function testStringEnum(): void {
     $cases = vec[
       shape(
-        'input' => darray['enum_string' => 'one'],
-        'output' => darray['enum_string' => 'one'],
+        'input' => dict['enum_string' => 'one'],
+        'output' => dict['enum_string' => 'one'],
         'valid' => true,
       ),
       shape(
-        'input' => darray['enum_string' => 'four'],
+        'input' => dict['enum_string' => 'four'],
         'valid' => false,
       ),
       shape(
-        'input' => darray['enum_string' => 1],
+        'input' => dict['enum_string' => 1],
         'valid' => false,
       ),
     ];

--- a/tests/GeneratedHackEnumSchemaValidatorTest.php
+++ b/tests/GeneratedHackEnumSchemaValidatorTest.php
@@ -3,7 +3,7 @@
 namespace Slack\Hack\JsonSchema\Tests;
 
 
-use type Slack\Hack\JsonSchema\Tests\Generated\EnumSchemaValidator;
+use type Slack\Hack\JsonSchema\Tests\Generated\GeneratedHackEnumSchemaValidator;
 
 final class GeneratedHackEnumSchemaValidatorTest extends BaseCodegenTestCase {
 
@@ -12,5 +12,24 @@ final class GeneratedHackEnumSchemaValidatorTest extends BaseCodegenTestCase {
 		$ret = self::getBuilder('generated-hack-enum-schema.json', 'GeneratedHackEnumSchemaValidator');
 		$ret['codegen']->build();
 		require_once($ret['path']);
+	}
+	public function testStringEnum(): void {
+		$cases = vec[
+			shape(
+				'input' => darray['enum_string' => 'one'],
+				'output' => darray['enum_string' => 'one'],
+				'valid' => true,
+			),
+			shape(
+				'input' => darray['enum_string' => 'four'],
+				'valid' => false,
+			),
+			shape(
+				'input' => darray['enum_string' => 1],
+				'valid' => false,
+			),
+		];
+
+		$this->expectCases($cases, $input ==> new GeneratedHackEnumSchemaValidator($input));
 	}
 }

--- a/tests/StringSchemaValidatorTest.php
+++ b/tests/StringSchemaValidatorTest.php
@@ -140,5 +140,6 @@ final class StringSchemaValidatorTest extends BaseCodegenTestCase {
     ];
 
     $this->expectCases($cases, $input ==> new StringSchemaValidator($input));
-	}
+  }
+
 }

--- a/tests/StringSchemaValidatorTest.php
+++ b/tests/StringSchemaValidatorTest.php
@@ -140,6 +140,5 @@ final class StringSchemaValidatorTest extends BaseCodegenTestCase {
     ];
 
     $this->expectCases($cases, $input ==> new StringSchemaValidator($input));
-  }
-
+	}
 }

--- a/tests/examples/codegen/GeneratedHackEnumSchemaValidator.php
+++ b/tests/examples/codegen/GeneratedHackEnumSchemaValidator.php
@@ -1,0 +1,85 @@
+<?hh // strict
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * To re-generate this file run `make test`
+ *
+ *
+ * @generated SignedSource<<ff65e010c6ed29ad1f95451eac4f8a17>>
+ */
+namespace Slack\Hack\JsonSchema\Tests\Generated;
+use namespace Slack\Hack\JsonSchema;
+use namespace Slack\Hack\JsonSchema\Constraints;
+
+type TGeneratedHackEnumSchemaValidator = shape(
+  ?'enum_string' => myCoolTestEnum,
+  ...
+);
+
+
+enum myCoolTestEnum : string as string {
+  ONE = 'one';
+  TWO = 'two';
+  THREE = 'three';
+}
+
+final class GeneratedHackEnumSchemaValidatorPropertiesEnumString {
+
+  private static bool $coerce = false;
+
+  public static function check(mixed $input, string $pointer): myCoolTestEnum {
+    $typed = Constraints\StringConstraint::check($input, $pointer, self::$coerce);
+
+    $typed = Constraints\HackEnumConstraint::check(
+      $typed,
+      myCoolTestEnum::class,
+      $pointer,
+    );
+    return $typed;
+  }
+}
+
+final class GeneratedHackEnumSchemaValidator
+  extends JsonSchema\BaseValidator<TGeneratedHackEnumSchemaValidator> {
+
+  private static bool $coerce = false;
+
+  public static function check(
+    mixed $input,
+    string $pointer,
+  ): TGeneratedHackEnumSchemaValidator {
+    $typed = Constraints\ObjectConstraint::check($input, $pointer, self::$coerce);
+
+    $errors = vec[];
+    $output = shape();
+
+    /*HHAST_IGNORE_ERROR[UnusedVariable] Some loops generated with this statement do not use their $value*/
+    foreach ($typed as $key => $value) {
+      /* HH_IGNORE_ERROR[4051] allow dynamic access to preserve input. See comment in the codegen lib for reasoning and alternatives if needed. */
+      $output[$key] = $value;
+    }
+
+    if (\HH\Lib\C\contains_key($typed, 'enum_string')) {
+      try {
+        $output['enum_string'] = GeneratedHackEnumSchemaValidatorPropertiesEnumString::check(
+          $typed['enum_string'],
+          JsonSchema\get_pointer($pointer, 'enum_string'),
+        );
+      } catch (JsonSchema\InvalidFieldException $e) {
+        $errors = \HH\Lib\Vec\concat($errors, $e->errors);
+      }
+    }
+
+    if (\HH\Lib\C\count($errors)) {
+      throw new JsonSchema\InvalidFieldException($pointer, $errors);
+    }
+
+    /* HH_IGNORE_ERROR[4163] */
+    return $output;
+  }
+
+  <<__Override>>
+  protected function process(): TGeneratedHackEnumSchemaValidator {
+    return self::check($this->input, $this->pointer);
+  }
+}

--- a/tests/examples/generated-hack-enum-schema.json
+++ b/tests/examples/generated-hack-enum-schema.json
@@ -1,0 +1,12 @@
+{
+	"type": "object",
+	"properties": {
+	  "enum_string": {
+		"type": "string",
+		"enum": ["one", "two", "three"],
+		"generateHackEnum": true,
+		"hackEnum": "myCoolTestEnum"
+	  }
+	}
+  }
+  

--- a/tests/examples/generated-hack-enum-schema.json
+++ b/tests/examples/generated-hack-enum-schema.json
@@ -8,5 +8,4 @@
     "hackEnum": "myCoolTestEnum"
     }
   }
-  }
-  
+}

--- a/tests/examples/generated-hack-enum-schema.json
+++ b/tests/examples/generated-hack-enum-schema.json
@@ -1,12 +1,12 @@
 {
-	"type": "object",
-	"properties": {
-	  "enum_string": {
-		"type": "string",
-		"enum": ["one", "two", "three"],
-		"generateHackEnum": true,
-		"hackEnum": "myCoolTestEnum"
-	  }
-	}
+  "type": "object",
+  "properties": {
+    "enum_string": {
+    "type": "string",
+    "enum": ["one", "two", "three"],
+    "generateHackEnum": true,
+    "hackEnum": "myCoolTestEnum"
+    }
+  }
   }
   


### PR DESCRIPTION
When users provide enum, hackEnum, and generateHackEnum: true, we'll generate a class they can use.

Known issues:

- [x] white space - my dev box was using tabs instead of two spaces. i resolved this using one liner:

```
git diff --name-only master | xargs sed -i $'s/\t/  /g'
```
